### PR TITLE
fix: Change rspec format from documentation to progress

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --require spec_helper
---format documentation
+--format progress
 --color


### PR DESCRIPTION
## Summary
- `.rspec` の出力フォーマットを `documentation` から `progress` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)