### PR TITLE
fix: Initialize rbenv via CLAUDE_ENV_FILE for Claude Code web

### DIFF
--- a/.claude/env.sh
+++ b/.claude/env.sh
@@ -1,0 +1,8 @@
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  eval "$(rbenv init - bash)"
+  # Bundler 4.0 + Ruby 3.3 compatibility workaround:
+  # Bundler 4.0's vendored net-http-persistent uses CGI.unescape which
+  # references @@accept_charset before it's initialized in Ruby 3.3.
+  # Pre-loading the CGI library via RUBYOPT resolves this.
+  export RUBYOPT="-rcgi"
+fi

--- a/.claude/hooks/claude-code-web-session-start.sh
+++ b/.claude/hooks/claude-code-web-session-start.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
-# Only run in Claude Code on the web (remote environment)
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  eval "$(rbenv init - bash)"
+
+  RUBYOPT="-rcgi" bundle install
 fi
-
-# Bundler 4.0 + Ruby 3.3 compatibility workaround:
-# Bundler 4.0's vendored net-http-persistent uses CGI.unescape which
-# references @@accept_charset before it's initialized in Ruby 3.3.
-# Pre-loading the CGI library via RUBYOPT resolves this.
-echo 'export RUBYOPT="-rcgi"' >> "$CLAUDE_ENV_FILE"
-
-RUBYOPT="-rcgi" bundle install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_ENV_FILE": "$CLAUDE_PROJECT_DIR/.claude/env.sh"
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
- Add .claude/env.sh that initializes rbenv and exports RUBYOPT on web
- Configure CLAUDE_ENV_FILE in settings.json to point to env.sh
- Simplify session-start hook to only run rbenv init and bundle install
- Fix Gemfile gem ordering and add desc to steep task
- Add spec/spec_helper.rb