### PR TITLE
fix: Use CLAUDE_ENV_FILE correctly for rbenv persistence in web sessions

### DIFF
--- a/.claude/env.sh
+++ b/.claude/env.sh
@@ -1,8 +1,0 @@
-if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  eval "$(rbenv init - bash)"
-  # Bundler 4.0 + Ruby 3.3 compatibility workaround:
-  # Bundler 4.0's vendored net-http-persistent uses CGI.unescape which
-  # references @@accept_charset before it's initialized in Ruby 3.3.
-  # Pre-loading the CGI library via RUBYOPT resolves this.
-  export RUBYOPT="-rcgi"
-fi

--- a/.claude/hooks/claude-code-web-session-start.sh
+++ b/.claude/hooks/claude-code-web-session-start.sh
@@ -3,6 +3,7 @@ set -eu
 
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
   eval "$(rbenv init - bash)"
-
+  echo 'eval "$(rbenv init - bash)"' >> "$CLAUDE_ENV_FILE"
+  echo 'export RUBYOPT="-rcgi"' >> "$CLAUDE_ENV_FILE"
   RUBYOPT="-rcgi" bundle install
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "env": {
-    "CLAUDE_ENV_FILE": "$CLAUDE_PROJECT_DIR/.claude/env.sh"
-  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
CLAUDE_ENV_FILE is managed by Claude Code itself. Write rbenv init and RUBYOPT to it in the SessionStart hook instead of overriding it in settings.json. Remove the now-obsolete env.sh file.