### PR TITLE
fix: Remove unnecessary matcher field from SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,6 @@
     ],
     "SessionStart": [
       {
-        "matcher": "startup",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
SessionStart イベントはセッション開始時に必ず実行されるため、
matcher による絞り込みは不要なフィールドだったため削除した。