### PR TITLE
fix: Set the latest Ruby version as global default in web session sta…

### DIFF
--- a/.claude/hooks/claude-code-web-session-start.sh
+++ b/.claude/hooks/claude-code-web-session-start.sh
@@ -3,6 +3,10 @@ set -eu
 
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
   eval "$(rbenv init - bash)"
+
+  # Set the latest installed Ruby version as the global default
+  rbenv global `rbenv versions --bare | sort -rV | head -1`
+
   echo 'eval "$(rbenv init - bash)"' >> "$CLAUDE_ENV_FILE"
   echo 'export RUBYOPT="-rcgi"' >> "$CLAUDE_ENV_FILE"
   RUBYOPT="-rcgi" bundle install


### PR DESCRIPTION
…rt hook

Added rbenv global command to automatically select the latest installed Ruby version before running bundle install, ensuring the correct version is used throughout the session.