### PR TITLE
fix: Add rbenv init to rbs-inline hook for web sessions

### DIFF
--- a/.claude/hooks/rbs-inline.sh
+++ b/.claude/hooks/rbs-inline.sh
@@ -6,6 +6,10 @@ tool_name=$(echo "$input" | jq -r '.tool_name')
 
 cd "$CLAUDE_PROJECT_DIR" || exit 1
 
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  eval "$(rbenv init - bash)"
+fi
+
 # Handle Edit or Write tools
 if [[ "$tool_name" == "Edit" || "$tool_name" == "Write" ]]; then
     file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""')


### PR DESCRIPTION
Web セッションでは rbenv の PATH が設定されないため、
rbs-inline.sh で bundle exec を呼ぶ前に rbenv init が必要。
pre-commit-check.sh と同様に CLAUDE_CODE_REMOTE 条件付きで追加。