### PR TITLE
Add CI status tracking to repositories

### DIFF
--- a/lib/github/repository.rb
+++ b/lib/github/repository.rb
@@ -2,7 +2,8 @@
 
 module GitHub
   Repository = Data.define(
-    :name,       #: String
-    :updated_at  #: Time
+    :name,        #: String
+    :updated_at,  #: Time
+    :ci_failing   #: bool
   )
 end

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -5,18 +5,34 @@ require_relative "repository"
 
 module GitHub
   class RepositoryFetcher
-    # @rbs @client: Octokit::Client
-
     # @rbs client: Octokit::Client
     def initialize(client:) #: void
       @client = client
+      @login = client.user.login
     end
 
     def repositories #: Array[GitHub::Repository]
-      login = @client.user.login
-      @client.repos(login, type: "owner").map do |repo|
-        Repository.new(name: repo.name, updated_at: repo.updated_at)
+      client.repos(login, type: "owner").map do |repo|
+        Repository.new(name: repo.name, updated_at: repo.updated_at,
+                       ci_failing: ci_failing?(repo.name, repo.default_branch))
       end
+    end
+
+    private
+
+    attr_reader :client #: Octokit::Client
+    attr_reader :login  #: String
+
+    # @rbs repo_name: String
+    # @rbs branch: String
+    def ci_failing?(repo_name, branch) #: bool
+      runs = client.workflow_runs("#{login}/#{repo_name}", per_page: 1, branch:).workflow_runs
+      return false if runs.empty?
+
+      run = runs.first
+      return false unless run
+
+      run.conclusion != "success"
     end
   end
 end

--- a/sig/gems/octokit.rbs
+++ b/sig/gems/octokit.rbs
@@ -5,6 +5,15 @@ end
 interface _OctokitRepo
   def name: () -> String
   def updated_at: () -> Time
+  def default_branch: () -> String
+end
+
+interface _OctokitWorkflowRun
+  def conclusion: () -> String?
+end
+
+interface _OctokitWorkflowRuns
+  def workflow_runs: () -> Array[_OctokitWorkflowRun]
 end
 
 module Octokit
@@ -14,6 +23,8 @@ module Octokit
     def user: () -> _OctokitUser
 
     def repos: (String, ?type: String) -> Array[_OctokitRepo]
+
+    def workflow_runs: (String, ?per_page: Integer, ?branch: String) -> _OctokitWorkflowRuns
 
   end
 end

--- a/sig/github/repository.rbs
+++ b/sig/github/repository.rbs
@@ -6,11 +6,13 @@ module GitHub
 
     attr_reader updated_at(): Time
 
-    def self.new: (String name, Time updated_at) -> instance
-                | (name: String, updated_at: Time) -> instance
+    attr_reader ci_failing(): bool
 
-    def self.members: () -> [ :name, :updated_at ]
+    def self.new: (String name, Time updated_at, bool ci_failing) -> instance
+                | (name: String, updated_at: Time, ci_failing: bool) -> instance
 
-    def members: () -> [ :name, :updated_at ]
+    def self.members: () -> [ :name, :updated_at, :ci_failing ]
+
+    def members: () -> [ :name, :updated_at, :ci_failing ]
   end
 end

--- a/sig/github/repository_fetcher.rbs
+++ b/sig/github/repository_fetcher.rbs
@@ -2,11 +2,19 @@
 
 module GitHub
   class RepositoryFetcher
-    @client: Octokit::Client
-
     # @rbs client: Octokit::Client
     def initialize: (client: Octokit::Client) -> void
 
     def repositories: () -> Array[GitHub::Repository]
+
+    private
+
+    attr_reader client: Octokit::Client
+
+    attr_reader login: String
+
+    # @rbs repo_name: String
+    # @rbs branch: String
+    def ci_failing?: (String repo_name, String branch) -> bool
   end
 end

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -7,24 +7,29 @@ RSpec.describe GitHub::RepositoryFetcher do
   subject(:fetcher) { described_class.new(client:) }
 
   let(:client) { instance_double(Octokit::Client) }
+  let(:user) { double(login: "testuser") }
+
+  before do
+    allow(client).to receive(:user).and_return(user)
+  end
 
   describe "#repositories" do
-    let(:user) { double(login: "testuser") }
-
-    before do
-      allow(client).to receive(:user).and_return(user)
-    end
-
     context "when user has repositories" do
       let(:repos) do
         [
-          double(name: "repo1", updated_at: Time.new(2025, 1, 1)),
-          double(name: "repo2", updated_at: Time.new(2025, 6, 1))
+          double(name: "repo1", updated_at: Time.new(2025, 1, 1), default_branch: "main"),
+          double(name: "repo2", updated_at: Time.new(2025, 6, 1), default_branch: "master")
         ]
       end
+      let(:workflow_runs_success) { double(workflow_runs: [double(conclusion: "success")]) }
+      let(:workflow_runs_failure) { double(workflow_runs: [double(conclusion: "failure")]) }
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
+        allow(client).to receive(:workflow_runs)
+          .with("testuser/repo1", per_page: 1, branch: "main").and_return(workflow_runs_success)
+        allow(client).to receive(:workflow_runs)
+          .with("testuser/repo2", per_page: 1, branch: "master").and_return(workflow_runs_failure)
       end
 
       it "returns an array of Repository objects" do
@@ -39,6 +44,29 @@ RSpec.describe GitHub::RepositoryFetcher do
         result = fetcher.repositories
         expect(result[0].name).to eq("repo1")
         expect(result[0].updated_at).to eq(Time.new(2025, 1, 1))
+      end
+
+      it "sets ci_failing to false when latest run succeeded" do
+        expect(fetcher.repositories[0].ci_failing).to be false
+      end
+
+      it "sets ci_failing to true when latest run failed" do
+        expect(fetcher.repositories[1].ci_failing).to be true
+      end
+    end
+
+    context "when repository has no workflow runs" do
+      let(:repos) { [double(name: "repo1", updated_at: Time.new(2025, 1, 1), default_branch: "main")] }
+      let(:empty_runs) { double(workflow_runs: []) }
+
+      before do
+        allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
+        allow(client).to receive(:workflow_runs).with("testuser/repo1", per_page: 1,
+                                                                        branch: "main").and_return(empty_runs)
+      end
+
+      it "sets ci_failing to false" do
+        expect(fetcher.repositories[0].ci_failing).to be false
       end
     end
 


### PR DESCRIPTION
## Changes

- Add `ci_failing` field to `GitHub::Repository` data class to track CI status
- Implement `ci_failing?` private method in `RepositoryFetcher` to check GitHub Actions workflow status
- Fetch the latest workflow run for each repository and determine if CI is failing
- Update type signatures in RBS files for `Repository`, `RepositoryFetcher`, and Octokit interfaces
- Add comprehensive test coverage for CI status detection including success, failure, and empty workflow runs
- Refactor `RepositoryFetcher#initialize` to cache login for reuse in workflow checks

## Implementation Details

The `ci_failing?` method queries the GitHub API for the latest workflow run and returns `true` if the conclusion is not "success" (or if no runs exist, defaults to `false`).