### PR TITLE
Update rbs_collection.lock.yaml to include octokit types from gem collection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,12 +8,17 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: :ci
 
-task ci: %i[rubocop spec steep]
+task ci: %i[rubocop spec rbs:validate steep]
 
 namespace :rbs do
   desc "Generate RBS files"
   task :generate do
     sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
+  desc "Validate RBS files"
+  task :validate do
+    sh "bundle exec rbs -Isig validate"
   end
 end
 

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -9,6 +9,14 @@ gems:
     revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: addressable
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: ast
   version: '2.4'
   source:
@@ -57,6 +65,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: diff-lcs
+  version: '1.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: digest
   version: '0'
   source:
@@ -65,6 +81,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: faraday
+  version: '2.7'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: ffi
   version: 1.17.3
   source:
@@ -106,9 +130,13 @@ gems:
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: minitest
   version: '5.25'
   source:
@@ -125,6 +153,22 @@ gems:
   version: 0.3.0
   source:
     type: rubygems
+- name: net-http
+  version: '0'
+  source:
+    type: stdlib
+- name: net-protocol
+  version: '0'
+  source:
+    type: stdlib
+- name: octokit
+  version: '8.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: openssl
   version: '0'
   source:
@@ -155,6 +199,14 @@ gems:
     type: rubygems
 - name: rainbow
   version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 60d59c1b63ad551a5db5a6b62e8efe726b8815bf
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
   source:
     type: git
     name: ruby/gem_rbs_collection

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -13,7 +13,9 @@ sources:
 # A directory to install the downloaded RBSs
 path: .gem_rbs_collection
 
-# gems:
-#   # If you want to avoid installing rbs files for gems, you can specify them here.
-#   - name: GEM_NAME
-#     ignore: true
+gems:
+  # rubocop-rbs_inline bundles partial types for these gems that conflict
+  # with gem_rbs_collection. Ignore rubocop-rbs_inline to use the more
+  # complete collection types instead.
+  - name: rubocop-rbs_inline
+    ignore: true

--- a/sig/gems/octokit.rbs
+++ b/sig/gems/octokit.rbs
@@ -18,15 +18,13 @@ end
 
 module Octokit
   class Client
-    def initialize: (?access_token: String) -> void
-
-    def user: () -> _OctokitUser
+    def user: (?(Integer | String) user, ?Hash[untyped, untyped] options) -> _OctokitUser
+            | ...
 
     def repos: (String, ?type: String) -> Array[_OctokitRepo]
 
     def workflow_runs: (String, ?per_page: Integer, ?branch: String) -> _OctokitWorkflowRuns
 
     def pull_requests: (String, ?state: String) -> Array[untyped]
-
   end
 end


### PR DESCRIPTION
rbs collection update picked up newly available types including octokit,
faraday, addressable, diff-lcs, rake, and others from gem_rbs_collection.

https://claude.ai/code/session_0128b3iRGCu8DiXdGSsWyXis