### PR TITLE
Fix CI status detection and improve developer experience

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ Style/Documentation:
 Style/HashSyntax:
   EnforcedShorthandSyntax: always
 
+Style/ItBlockParameter:
+  Enabled: false
+
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 # gem "rails"
 
+gem "faraday-retry"
 gem "octokit"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.3)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
@@ -169,6 +171,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  faraday-retry
   octokit
   rake
   rbs
@@ -194,6 +197,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
   ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
   ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2

--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -7,9 +7,10 @@ require_relative "../github/repository_fetcher"
 module Ghscan
   class Main
     def run #: void
+      debug = ARGV.include?("--debug")
       token = fetch_token
       client = build_client(token)
-      fetcher = GitHub::RepositoryFetcher.new(client:)
+      fetcher = GitHub::RepositoryFetcher.new(client:, debug:)
       puts JSON.generate(format_output(fetcher.repositories))
     end
 

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -6,23 +6,34 @@ require_relative "repository"
 module GitHub
   class RepositoryFetcher
     # @rbs client: Octokit::Client
-    def initialize(client:) #: void
+    # @rbs debug: bool
+    def initialize(client:, debug: false) #: void
       @client = client
       @login = client.user.login
+      @debug = debug
     end
 
     def repositories #: Array[GitHub::Repository]
-      client.repos(login, type: "owner").map do |repo|
-        Repository.new(name: repo.name, updated_at: repo.updated_at,
-                       ci_failing: ci_failing?(repo.name, repo.default_branch),
-                       pull_requests_count: pull_requests_count(repo.name))
-      end
+      repos = client.repos(login, type: "owner")
+      warn "[debug] Found #{repos.length} repositories" if debug
+      repos.map.with_index(1) { |repo, i| build_repository(repo, i, repos.length) }
     end
 
     private
 
     attr_reader :client #: Octokit::Client
     attr_reader :login  #: String
+    attr_reader :debug  #: bool
+
+    # @rbs repo: untyped
+    # @rbs index: Integer
+    # @rbs total: Integer
+    def build_repository(repo, index, total) #: GitHub::Repository
+      warn "[debug] Processing #{repo.name} (#{index}/#{total})" if debug
+      Repository.new(name: repo.name, updated_at: repo.updated_at,
+                     ci_failing: ci_failing?(repo.name, repo.default_branch),
+                     pull_requests_count: pull_requests_count(repo.name))
+    end
 
     # @rbs repo_name: String
     def pull_requests_count(repo_name) #: Integer
@@ -32,13 +43,12 @@ module GitHub
     # @rbs repo_name: String
     # @rbs branch: String
     def ci_failing?(repo_name, branch) #: bool
-      runs = client.workflow_runs("#{login}/#{repo_name}", per_page: 1, branch:).workflow_runs
+      runs = client.get("repos/#{login}/#{repo_name}/actions/runs", branch:, per_page: 100).workflow_runs
       return false if runs.empty?
 
-      run = runs.first
-      return false unless run
-
-      run.conclusion != "success"
+      latest_sha = runs.first&.head_sha or return false
+      latest_runs = runs.select { _1.head_sha == latest_sha }
+      latest_runs.any? { _1.conclusion != "success" }
     end
   end
 end

--- a/sig/gems/octokit.rbs
+++ b/sig/gems/octokit.rbs
@@ -9,6 +9,7 @@ interface _OctokitRepo
 end
 
 interface _OctokitWorkflowRun
+  def head_sha: () -> String
   def conclusion: () -> String?
 end
 
@@ -24,7 +25,7 @@ module Octokit
 
     def repos: (String, ?type: String) -> Array[_OctokitRepo]
 
-    def workflow_runs: (String, ?per_page: Integer, ?branch: String) -> _OctokitWorkflowRuns
+    def get: (String, ?branch: String, ?per_page: Integer) -> _OctokitWorkflowRuns
 
     def pull_requests: (String, ?state: String) -> Array[untyped]
 

--- a/sig/github/repository_fetcher.rbs
+++ b/sig/github/repository_fetcher.rbs
@@ -3,7 +3,8 @@
 module GitHub
   class RepositoryFetcher
     # @rbs client: Octokit::Client
-    def initialize: (client: Octokit::Client) -> void
+    # @rbs debug: bool
+    def initialize: (client: Octokit::Client, ?debug: bool) -> void
 
     def repositories: () -> Array[GitHub::Repository]
 
@@ -12,6 +13,13 @@ module GitHub
     attr_reader client: Octokit::Client
 
     attr_reader login: String
+
+    attr_reader debug: bool
+
+    # @rbs repo: untyped
+    # @rbs index: Integer
+    # @rbs total: Integer
+    def build_repository: (untyped repo, Integer index, Integer total) -> GitHub::Repository
 
     # @rbs repo_name: String
     def pull_requests_count: (String repo_name) -> Integer

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Ghscan::Main do
 
       before do
         allow(ENV).to receive(:fetch).with("GITHUB_TOKEN", nil).and_return("test-token")
-        allow(GitHub::RepositoryFetcher).to receive(:new).with(client:).and_return(fetcher)
+        allow(GitHub::RepositoryFetcher).to receive(:new).with(client:, debug: false).and_return(fetcher)
       end
 
       it "outputs JSON to stdout" do
@@ -65,7 +65,7 @@ RSpec.describe Ghscan::Main do
 
       before do
         allow(ENV).to receive(:fetch).with("GITHUB_TOKEN", nil).and_return("test-token")
-        allow(GitHub::RepositoryFetcher).to receive(:new).with(client:).and_return(fetcher)
+        allow(GitHub::RepositoryFetcher).to receive(:new).with(client:, debug: false).and_return(fetcher)
       end
 
       it "outputs an empty JSON array to stdout" do

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -21,15 +21,27 @@ RSpec.describe GitHub::RepositoryFetcher do
           double(name: "repo2", updated_at: Time.new(2025, 6, 1), default_branch: "master")
         ]
       end
-      let(:workflow_runs_success) { double(workflow_runs: [double(conclusion: "success")]) }
-      let(:workflow_runs_failure) { double(workflow_runs: [double(conclusion: "failure")]) }
+      let(:workflow_runs_success) do
+        double(workflow_runs: [
+                 double(head_sha: "abc123", conclusion: "success"),
+                 double(head_sha: "abc123", conclusion: "success"),
+                 double(head_sha: "prev456", conclusion: "failure")
+               ])
+      end
+      let(:workflow_runs_failure) do
+        double(workflow_runs: [
+                 double(head_sha: "def789", conclusion: "success"),
+                 double(head_sha: "def789", conclusion: "failure"),
+                 double(head_sha: "prev456", conclusion: "success")
+               ])
+      end
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
-        allow(client).to receive(:workflow_runs)
-          .with("testuser/repo1", per_page: 1, branch: "main").and_return(workflow_runs_success)
-        allow(client).to receive(:workflow_runs)
-          .with("testuser/repo2", per_page: 1, branch: "master").and_return(workflow_runs_failure)
+        allow(client).to receive(:get)
+          .with("repos/testuser/repo1/actions/runs", branch: "main", per_page: 100).and_return(workflow_runs_success)
+        allow(client).to receive(:get)
+          .with("repos/testuser/repo2/actions/runs", branch: "master", per_page: 100).and_return(workflow_runs_failure)
         allow(client).to receive(:pull_requests)
           .with("testuser/repo1", state: "open").and_return([double, double, double])
         allow(client).to receive(:pull_requests)
@@ -50,11 +62,12 @@ RSpec.describe GitHub::RepositoryFetcher do
         expect(result[0].updated_at).to eq(Time.new(2025, 1, 1))
       end
 
-      it "sets ci_failing to false when latest run succeeded" do
+      it "sets ci_failing to false when all latest runs succeeded, ignoring older failures" do
+        # repo1: latest sha (abc123) all succeeded, previous sha (prev456) had a failure
         expect(fetcher.repositories[0].ci_failing).to be false
       end
 
-      it "sets ci_failing to true when latest run failed" do
+      it "sets ci_failing to true when any latest run failed" do
         expect(fetcher.repositories[1].ci_failing).to be true
       end
 
@@ -71,8 +84,8 @@ RSpec.describe GitHub::RepositoryFetcher do
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
-        allow(client).to receive(:workflow_runs).with("testuser/repo1", per_page: 1,
-                                                                        branch: "main").and_return(empty_runs)
+        allow(client).to receive(:get)
+          .with("repos/testuser/repo1/actions/runs", branch: "main", per_page: 100).and_return(empty_runs)
         allow(client).to receive(:pull_requests).with("testuser/repo1", state: "open").and_return([])
       end
 


### PR DESCRIPTION
- Add faraday-retry gem to suppress Faraday v2 warning
- Add --debug option to print per-repository progress to stderr
- Fix workflow_runs API call (use client.get to avoid auto_paginate fetching all pages)
- Group CI runs by head_sha to evaluate all workflows triggered by the latest commit together