### PR TITLE
Include all repository attributes in ghscan output

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -31,9 +31,15 @@ module Ghscan
     end
 
     # @rbs repositories: Array[GitHub::Repository]
-    def format_output(repositories) #: Array[Hash[String, String]]
+    def format_output(repositories) #: Array[Hash[String, untyped]]
       repositories.map do |repo|
-        { "name" => repo.name, "updated_at" => repo.updated_at.iso8601 }
+        {
+          "name" => repo.name,
+          "updated_at" => repo.updated_at.iso8601,
+          "ci_failing" => repo.ci_failing,
+          "pull_requests_count" => repo.pull_requests_count,
+          "language_versions" => repo.language_versions
+        }
       end
     end
   end

--- a/sig/ghscan/main.rbs
+++ b/sig/ghscan/main.rbs
@@ -12,6 +12,6 @@ module Ghscan
     def build_client: (String token) -> Octokit::Client
 
     # @rbs repositories: Array[GitHub::Repository]
-    def format_output: (Array[GitHub::Repository] repositories) -> Array[Hash[String, String]]
+    def format_output: (Array[GitHub::Repository] repositories) -> Array[Hash[String, untyped]]
   end
 end

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -40,14 +40,22 @@ RSpec.describe Ghscan::Main do
     context "when GITHUB_TOKEN is set" do
       let(:repos) do
         [
-          instance_double(GitHub::Repository, name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00")),
-          instance_double(GitHub::Repository, name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"))
+          instance_double(GitHub::Repository,
+                          name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+                          ci_failing: false, pull_requests_count: 2,
+                          language_versions: { "ruby" => ["3.2"] }),
+          instance_double(GitHub::Repository,
+                          name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
+                          ci_failing: true, pull_requests_count: 0,
+                          language_versions: {})
         ]
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
-        '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00"},' \
-          '{"name":"repo2","updated_at":"2025-06-01T00:00:00+00:00"}]'
+        '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00",' \
+          '"ci_failing":false,"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
+          '{"name":"repo2","updated_at":"2025-06-01T00:00:00+00:00",' \
+          '"ci_failing":true,"pull_requests_count":0,"language_versions":{}}]'
       end
 
       before do
@@ -77,16 +85,26 @@ RSpec.describe Ghscan::Main do
   describe "#format_output" do
     let(:repos) do
       [
-        instance_double(GitHub::Repository, name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00")),
-        instance_double(GitHub::Repository, name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"))
+        instance_double(GitHub::Repository,
+                        name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+                        ci_failing: false, pull_requests_count: 2,
+                        language_versions: { "ruby" => ["3.2"] }),
+        instance_double(GitHub::Repository,
+                        name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
+                        ci_failing: true, pull_requests_count: 0,
+                        language_versions: {})
       ]
     end
 
-    it "returns an array of hashes with name and updated_at" do
+    it "returns an array of hashes with all repository attributes" do
       result = main.send(:format_output, repos)
       expect(result).to eq([
-                             { "name" => "repo1", "updated_at" => "2025-01-01T00:00:00+00:00" },
-                             { "name" => "repo2", "updated_at" => "2025-06-01T00:00:00+00:00" }
+                             { "name" => "repo1", "updated_at" => "2025-01-01T00:00:00+00:00",
+                               "ci_failing" => false, "pull_requests_count" => 2,
+                               "language_versions" => { "ruby" => ["3.2"] } },
+                             { "name" => "repo2", "updated_at" => "2025-06-01T00:00:00+00:00",
+                               "ci_failing" => true, "pull_requests_count" => 0,
+                               "language_versions" => {} }
                            ])
     end
 


### PR DESCRIPTION
## Summary

- `format_output` メソッドに `ci_failing`、`pull_requests_count`、`language_versions` を追加
- `ghscan` コマンドの JSON 出力にこれらの属性が含まれるようになった
- RBS 型シグネチャを `Array[Hash[String, untyped]]` に更新
- テストを新属性に合わせて更新

## Test plan

- [ ] `bundle exec rspec spec/ghscan/main_spec.rb` がすべてパスすることを確認
- [ ] `ghscan` コマンドの出力に `ci_failing`、`pull_requests_count`、`language_versions` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)