### PR TITLE
Add worktree git instructions to self-review hook

### DIFF
--- a/.claude/hooks/self-review.sh
+++ b/.claude/hooks/self-review.sh
@@ -54,7 +54,11 @@ Check for:
    suggest squashing them into the relevant commit before merging.
 
 Report findings and suggest fixes if needed.
-After the subagent review, if issues are found, create follow-up commits to address them.'
+After the subagent review, if issues are found, create follow-up commits to address them.
+
+If working in a git worktree (i.e., the working directory is under .claude/worktrees/),
+use `git -C <worktree-path>` for all git commands instead of `cd <path> && git`.
+Also avoid chaining commands with `&&` where possible — run each command separately.'
 
 jq -n --arg reason "$review_prompt" '{
   "decision": "block",

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # NOTE: Entries are sorted in ASCII order.
 
 /.claude/settings.local.json
+/.claude/worktrees/
 /.gem_rbs_collection/
 /vendor/bundle/


### PR DESCRIPTION
## Summary

- worktree 環境での self-review 時に `cd <path> && git` の代わりに `git -C <path>` を使うよう指示を追加
- `&&` によるコマンド連結を可能な限り避けるよう指示を追加
- `.claude/worktrees/` を `.gitignore` に追加

## Test plan

- [ ] git push 後に self-review が実行されること
- [ ] worktree 内での self-review で `git -C` が使われること

🤖 Generated with [Claude Code](https://claude.com/claude-code)