### PR TITLE
Filter repositories by CI status and open PR count

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -11,7 +11,7 @@ module Ghscan
       token = fetch_token
       client = build_client(token)
       fetcher = GitHub::RepositoryFetcher.new(client:, debug:)
-      puts JSON.generate(format_output(fetcher.repositories))
+      puts JSON.generate(format_output(filter_repositories(fetcher.repositories)))
     end
 
     private
@@ -28,6 +28,11 @@ module Ghscan
     # @rbs token: String
     def build_client(token) #: Octokit::Client
       Octokit::Client.new(access_token: token, auto_paginate: true) # steep:ignore UnexpectedKeywordArgument
+    end
+
+    # @rbs repositories: Array[GitHub::Repository]
+    def filter_repositories(repositories) #: Array[GitHub::Repository]
+      repositories.select { _1.ci_failing && _1.pull_requests_count >= 1 }
     end
 
     # @rbs repositories: Array[GitHub::Repository]

--- a/sig/ghscan/main.rbs
+++ b/sig/ghscan/main.rbs
@@ -12,6 +12,9 @@ module Ghscan
     def build_client: (String token) -> Octokit::Client
 
     # @rbs repositories: Array[GitHub::Repository]
+    def filter_repositories: (Array[GitHub::Repository] repositories) -> Array[GitHub::Repository]
+
+    # @rbs repositories: Array[GitHub::Repository]
     def format_output: (Array[GitHub::Repository] repositories) -> Array[Hash[String, untyped]]
   end
 end

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -47,15 +47,17 @@ RSpec.describe Ghscan::Main do
           instance_double(GitHub::Repository,
                           name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
                           ci_failing: true, pull_requests_count: 0,
-                          language_versions: {})
+                          language_versions: {}),
+          instance_double(GitHub::Repository,
+                          name: "repo3", updated_at: Time.new(2025, 9, 1, 0, 0, 0, "+00:00"),
+                          ci_failing: true, pull_requests_count: 3,
+                          language_versions: { "ruby" => ["3.3"] })
         ]
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
-        '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00",' \
-          '"ci_failing":false,"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
-          '{"name":"repo2","updated_at":"2025-06-01T00:00:00+00:00",' \
-          '"ci_failing":true,"pull_requests_count":0,"language_versions":{}}]'
+        '[{"name":"repo3","updated_at":"2025-09-01T00:00:00+00:00",' \
+          '"ci_failing":true,"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
       end
 
       before do
@@ -63,7 +65,7 @@ RSpec.describe Ghscan::Main do
         allow(GitHub::RepositoryFetcher).to receive(:new).with(client:, debug: false).and_return(fetcher)
       end
 
-      it "outputs JSON to stdout" do
+      it "outputs only repositories with failing CI and open PRs as JSON to stdout" do
         expect { main.run }.to output("#{expected_json}\n").to_stdout
       end
     end
@@ -78,6 +80,28 @@ RSpec.describe Ghscan::Main do
 
       it "outputs an empty JSON array to stdout" do
         expect { main.run }.to output("[]\n").to_stdout
+      end
+    end
+  end
+
+  describe "#filter_repositories" do
+    let(:repos) do
+      [
+        instance_double(GitHub::Repository, name: "repo1", ci_failing: false, pull_requests_count: 2),
+        instance_double(GitHub::Repository, name: "repo2", ci_failing: true,  pull_requests_count: 0),
+        instance_double(GitHub::Repository, name: "repo3", ci_failing: true,  pull_requests_count: 1),
+        instance_double(GitHub::Repository, name: "repo4", ci_failing: true,  pull_requests_count: 3)
+      ]
+    end
+
+    it "returns only repositories with failing CI and at least one open PR" do
+      result = main.send(:filter_repositories, repos)
+      expect(result.map(&:name)).to eq(%w[repo3 repo4])
+    end
+
+    context "when repositories is empty" do
+      it "returns an empty array" do
+        expect(main.send(:filter_repositories, [])).to eq([])
       end
     end
   end


### PR DESCRIPTION
## Summary

- `filter_repositories` メソッドを追加し、CI が失敗しているかつオープンな PR が 1 件以上あるリポジトリのみ出力するようにした
- `run` メソッドで `format_output` の前にフィルタを適用
- `filter_repositories` のユニットテストおよび統合テストを追加

## Test plan

- [ ] `bundle exec rspec spec/ghscan/main_spec.rb` がすべてパスすること
- [ ] CI 失敗・PR なしのリポジトリが除外されること
- [ ] CI 正常・PR ありのリポジトリが除外されること
- [ ] CI 失敗・PR ありのリポジトリのみ出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)