### PR TITLE
Fix repository filter to use OR condition

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -32,7 +32,7 @@ module Ghscan
 
     # @rbs repositories: Array[GitHub::Repository]
     def filter_repositories(repositories) #: Array[GitHub::Repository]
-      repositories.select { _1.ci_failing && _1.pull_requests_count >= 1 }
+      repositories.select { _1.ci_failing || _1.pull_requests_count >= 1 }
     end
 
     # @rbs repositories: Array[GitHub::Repository]

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -56,7 +56,11 @@ RSpec.describe Ghscan::Main do
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
-        '[{"name":"repo3","updated_at":"2025-09-01T00:00:00+00:00",' \
+        '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00",' \
+          '"ci_failing":false,"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
+          '{"name":"repo2","updated_at":"2025-06-01T00:00:00+00:00",' \
+          '"ci_failing":true,"pull_requests_count":0,"language_versions":{}},' \
+          '{"name":"repo3","updated_at":"2025-09-01T00:00:00+00:00",' \
           '"ci_failing":true,"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
       end
 
@@ -65,7 +69,7 @@ RSpec.describe Ghscan::Main do
         allow(GitHub::RepositoryFetcher).to receive(:new).with(client:, debug: false).and_return(fetcher)
       end
 
-      it "outputs only repositories with failing CI and open PRs as JSON to stdout" do
+      it "outputs only repositories with failing CI or open PRs as JSON to stdout" do
         expect { main.run }.to output("#{expected_json}\n").to_stdout
       end
     end
@@ -87,16 +91,16 @@ RSpec.describe Ghscan::Main do
   describe "#filter_repositories" do
     let(:repos) do
       [
-        instance_double(GitHub::Repository, name: "repo1", ci_failing: false, pull_requests_count: 2),
-        instance_double(GitHub::Repository, name: "repo2", ci_failing: true,  pull_requests_count: 0),
-        instance_double(GitHub::Repository, name: "repo3", ci_failing: true,  pull_requests_count: 1),
+        instance_double(GitHub::Repository, name: "repo1", ci_failing: false, pull_requests_count: 0),
+        instance_double(GitHub::Repository, name: "repo2", ci_failing: false, pull_requests_count: 2),
+        instance_double(GitHub::Repository, name: "repo3", ci_failing: true,  pull_requests_count: 0),
         instance_double(GitHub::Repository, name: "repo4", ci_failing: true,  pull_requests_count: 3)
       ]
     end
 
-    it "returns only repositories with failing CI and at least one open PR" do
+    it "returns only repositories with failing CI or at least one open PR" do
       result = main.send(:filter_repositories, repos)
-      expect(result.map(&:name)).to eq(%w[repo3 repo4])
+      expect(result.map(&:name)).to eq(%w[repo2 repo3 repo4])
     end
 
     context "when repositories is empty" do


### PR DESCRIPTION
## Summary

- フィルタ条件を AND から OR に修正: CI が失敗している **または** オープンな PR が 1 件以上あるリポジトリを出力する
- テストデータと期待値を OR 条件に合わせて更新

## Test plan

- [ ] `bundle exec rspec spec/ghscan/main_spec.rb` がすべてパスすること
- [ ] CI 正常・PR なしのリポジトリのみ除外されること
- [ ] CI 失敗のみのリポジトリが含まれること
- [ ] PR ありのみのリポジトリが含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)