### PR TITLE
Remove ci_failing feature

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -32,7 +32,7 @@ module Ghscan
 
     # @rbs repositories: Array[GitHub::Repository]
     def filter_repositories(repositories) #: Array[GitHub::Repository]
-      repositories.select { _1.ci_failing || _1.pull_requests_count >= 1 }
+      repositories.select { _1.pull_requests_count >= 1 }
     end
 
     # @rbs repositories: Array[GitHub::Repository]
@@ -41,7 +41,6 @@ module Ghscan
         {
           "name" => repo.name,
           "updated_at" => repo.updated_at.iso8601,
-          "ci_failing" => repo.ci_failing,
           "pull_requests_count" => repo.pull_requests_count,
           "language_versions" => repo.language_versions
         }

--- a/lib/github/repository.rb
+++ b/lib/github/repository.rb
@@ -4,7 +4,6 @@ module GitHub
   Repository = Data.define(
     :name,                 #: String
     :updated_at,           #: Time
-    :ci_failing,           #: bool
     :pull_requests_count,  #: Integer
     :language_versions     #: Hash[String, Array[String]]
   )

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -43,7 +43,6 @@ module GitHub
     def build_repository(repo, index, total) #: GitHub::Repository
       warn "[debug] Processing #{repo.name} (#{index}/#{total})" if debug
       Repository.new(name: repo.name, updated_at: repo.updated_at,
-                     ci_failing: ci_failing?(repo.name, repo.default_branch),
                      pull_requests_count: pull_requests_count(repo.name),
                      language_versions: language_versions(repo.name))
     end
@@ -56,17 +55,6 @@ module GitHub
     # @rbs repo_name: String
     def language_versions(repo_name) #: Hash[String, Array[String]]
       WorkflowParser.new(client:, repo_full_name: "#{login}/#{repo_name}").language_versions
-    end
-
-    # @rbs repo_name: String
-    # @rbs branch: String
-    def ci_failing?(repo_name, branch) #: bool
-      runs = client.get("repos/#{login}/#{repo_name}/actions/runs", branch:, per_page: 100).workflow_runs
-      return false if runs.empty?
-
-      latest_sha = runs.first&.head_sha or return false
-      latest_runs = runs.select { _1.head_sha == latest_sha }
-      latest_runs.any? { _1.conclusion != "success" }
     end
   end
 end

--- a/sig/github/repository.rbs
+++ b/sig/github/repository.rbs
@@ -6,17 +6,15 @@ module GitHub
 
     attr_reader updated_at(): Time
 
-    attr_reader ci_failing(): bool
-
     attr_reader pull_requests_count(): Integer
 
     attr_reader language_versions(): Hash[String, Array[String]]
 
-    def self.new: (String name, Time updated_at, bool ci_failing, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
-                | (name: String, updated_at: Time, ci_failing: bool, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
+    def self.new: (String name, Time updated_at, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
+                | (name: String, updated_at: Time, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
 
-    def self.members: () -> [ :name, :updated_at, :ci_failing, :pull_requests_count, :language_versions ]
+    def self.members: () -> [ :name, :updated_at, :pull_requests_count, :language_versions ]
 
-    def members: () -> [ :name, :updated_at, :ci_failing, :pull_requests_count, :language_versions ]
+    def members: () -> [ :name, :updated_at, :pull_requests_count, :language_versions ]
   end
 end

--- a/sig/github/repository_fetcher.rbs
+++ b/sig/github/repository_fetcher.rbs
@@ -28,9 +28,5 @@ module GitHub
 
     # @rbs repo_name: String
     def language_versions: (String repo_name) -> Hash[String, Array[String]]
-
-    # @rbs repo_name: String
-    # @rbs branch: String
-    def ci_failing?: (String repo_name, String branch) -> bool
   end
 end

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -42,26 +42,24 @@ RSpec.describe Ghscan::Main do
         [
           instance_double(GitHub::Repository,
                           name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
-                          ci_failing: false, pull_requests_count: 2,
+                          pull_requests_count: 2,
                           language_versions: { "ruby" => ["3.2"] }),
           instance_double(GitHub::Repository,
                           name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
-                          ci_failing: true, pull_requests_count: 0,
+                          pull_requests_count: 0,
                           language_versions: {}),
           instance_double(GitHub::Repository,
                           name: "repo3", updated_at: Time.new(2025, 9, 1, 0, 0, 0, "+00:00"),
-                          ci_failing: true, pull_requests_count: 3,
+                          pull_requests_count: 3,
                           language_versions: { "ruby" => ["3.3"] })
         ]
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
         '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00",' \
-          '"ci_failing":false,"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
-          '{"name":"repo2","updated_at":"2025-06-01T00:00:00+00:00",' \
-          '"ci_failing":true,"pull_requests_count":0,"language_versions":{}},' \
+          '"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
           '{"name":"repo3","updated_at":"2025-09-01T00:00:00+00:00",' \
-          '"ci_failing":true,"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
+          '"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
       end
 
       before do
@@ -69,7 +67,7 @@ RSpec.describe Ghscan::Main do
         allow(GitHub::RepositoryFetcher).to receive(:new).with(client:, debug: false).and_return(fetcher)
       end
 
-      it "outputs only repositories with failing CI or open PRs as JSON to stdout" do
+      it "outputs only repositories with open PRs as JSON to stdout" do
         expect { main.run }.to output("#{expected_json}\n").to_stdout
       end
     end
@@ -91,16 +89,16 @@ RSpec.describe Ghscan::Main do
   describe "#filter_repositories" do
     let(:repos) do
       [
-        instance_double(GitHub::Repository, name: "repo1", ci_failing: false, pull_requests_count: 0),
-        instance_double(GitHub::Repository, name: "repo2", ci_failing: false, pull_requests_count: 2),
-        instance_double(GitHub::Repository, name: "repo3", ci_failing: true,  pull_requests_count: 0),
-        instance_double(GitHub::Repository, name: "repo4", ci_failing: true,  pull_requests_count: 3)
+        instance_double(GitHub::Repository, name: "repo1", pull_requests_count: 0),
+        instance_double(GitHub::Repository, name: "repo2", pull_requests_count: 2),
+        instance_double(GitHub::Repository, name: "repo3", pull_requests_count: 0),
+        instance_double(GitHub::Repository, name: "repo4", pull_requests_count: 3)
       ]
     end
 
-    it "returns only repositories with failing CI or at least one open PR" do
+    it "returns only repositories with at least one open PR" do
       result = main.send(:filter_repositories, repos)
-      expect(result.map(&:name)).to eq(%w[repo2 repo3 repo4])
+      expect(result.map(&:name)).to eq(%w[repo2 repo4])
     end
 
     context "when repositories is empty" do
@@ -115,11 +113,11 @@ RSpec.describe Ghscan::Main do
       [
         instance_double(GitHub::Repository,
                         name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
-                        ci_failing: false, pull_requests_count: 2,
+                        pull_requests_count: 2,
                         language_versions: { "ruby" => ["3.2"] }),
         instance_double(GitHub::Repository,
                         name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
-                        ci_failing: true, pull_requests_count: 0,
+                        pull_requests_count: 0,
                         language_versions: {})
       ]
     end
@@ -128,10 +126,10 @@ RSpec.describe Ghscan::Main do
       result = main.send(:format_output, repos)
       expect(result).to eq([
                              { "name" => "repo1", "updated_at" => "2025-01-01T00:00:00+00:00",
-                               "ci_failing" => false, "pull_requests_count" => 2,
+                               "pull_requests_count" => 2,
                                "language_versions" => { "ruby" => ["3.2"] } },
                              { "name" => "repo2", "updated_at" => "2025-06-01T00:00:00+00:00",
-                               "ci_failing" => true, "pull_requests_count" => 0,
+                               "pull_requests_count" => 0,
                                "language_versions" => {} }
                            ])
     end

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -25,27 +25,9 @@ RSpec.describe GitHub::RepositoryFetcher do
                  default_branch: "master", archived: false, fork: false)
         ]
       end
-      let(:workflow_runs_success) do
-        double(workflow_runs: [
-                 double(head_sha: "abc123", conclusion: "success"),
-                 double(head_sha: "abc123", conclusion: "success"),
-                 double(head_sha: "prev456", conclusion: "failure")
-               ])
-      end
-      let(:workflow_runs_failure) do
-        double(workflow_runs: [
-                 double(head_sha: "def789", conclusion: "success"),
-                 double(head_sha: "def789", conclusion: "failure"),
-                 double(head_sha: "prev456", conclusion: "success")
-               ])
-      end
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
-        allow(client).to receive(:get)
-          .with("repos/testuser/repo1/actions/runs", branch: "main", per_page: 100).and_return(workflow_runs_success)
-        allow(client).to receive(:get)
-          .with("repos/testuser/repo2/actions/runs", branch: "master", per_page: 100).and_return(workflow_runs_failure)
         allow(client).to receive(:pull_requests)
           .with("testuser/repo1", state: "open").and_return([double, double, double])
         allow(client).to receive(:pull_requests)
@@ -66,15 +48,6 @@ RSpec.describe GitHub::RepositoryFetcher do
         expect(result[0].updated_at).to eq(Time.new(2025, 1, 1))
       end
 
-      it "sets ci_failing to false when all latest runs succeeded, ignoring older failures" do
-        # repo1: latest sha (abc123) all succeeded, previous sha (prev456) had a failure
-        expect(fetcher.repositories[0].ci_failing).to be false
-      end
-
-      it "sets ci_failing to true when any latest run failed" do
-        expect(fetcher.repositories[1].ci_failing).to be true
-      end
-
       it "sets pull_requests_count correctly" do
         result = fetcher.repositories
         expect(result[0].pull_requests_count).to eq(3)
@@ -91,17 +64,12 @@ RSpec.describe GitHub::RepositoryFetcher do
         [double(name: "repo1", updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
                 default_branch: "main", archived: false, fork: false)]
       end
-      let(:workflow_runs_success) do
-        double(workflow_runs: [double(head_sha: "abc123", conclusion: "success")])
-      end
       let(:parser_with_versions) do
         instance_double(GitHub::WorkflowParser, language_versions: { "ruby" => ["3.1", "3.2"] })
       end
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
-        allow(client).to receive(:get)
-          .with("repos/testuser/repo1/actions/runs", branch: "main", per_page: 100).and_return(workflow_runs_success)
         allow(client).to receive(:pull_requests)
           .with("testuser/repo1", state: "open").and_return([])
         allow(GitHub::WorkflowParser).to receive(:new)
@@ -111,25 +79,6 @@ RSpec.describe GitHub::RepositoryFetcher do
 
       it "sets language_versions on the repository" do
         expect(fetcher.repositories[0].language_versions).to eq({ "ruby" => ["3.1", "3.2"] })
-      end
-    end
-
-    context "when repository has no workflow runs" do
-      let(:repos) do
-        [double(name: "repo1", updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
-                default_branch: "main", archived: false, fork: false)]
-      end
-      let(:empty_runs) { double(workflow_runs: []) }
-
-      before do
-        allow(client).to receive(:repos).with("testuser", type: "owner").and_return(repos)
-        allow(client).to receive(:get)
-          .with("repos/testuser/repo1/actions/runs", branch: "main", per_page: 100).and_return(empty_runs)
-        allow(client).to receive(:pull_requests).with("testuser/repo1", state: "open").and_return([])
-      end
-
-      it "sets ci_failing to false" do
-        expect(fetcher.repositories[0].ci_failing).to be false
       end
     end
 
@@ -160,13 +109,10 @@ RSpec.describe GitHub::RepositoryFetcher do
         double(name: "old", updated_at: Time.now, pushed_at: Time.now - (2 * 365 * 24 * 3600),
                default_branch: "main", archived: false, fork: false)
       end
-      let(:workflow_runs) { double(workflow_runs: [double(head_sha: "abc", conclusion: "success")]) }
 
       before do
         allow(client).to receive(:repos).with("testuser", type: "owner")
                                         .and_return([active_repo, archived_repo, forked_repo, old_repo])
-        allow(client).to receive(:get)
-          .with("repos/testuser/active/actions/runs", branch: "main", per_page: 100).and_return(workflow_runs)
         allow(client).to receive(:pull_requests).with("testuser/active", state: "open").and_return([])
       end
 


### PR DESCRIPTION
## Summary

- `ci_failing` フィールドを `GitHub::Repository` から削除
- `RepositoryFetcher` から `ci_failing?` メソッドと GitHub Actions API 呼び出しを削除
- `filter_repositories` を `pull_requests_count >= 1` のみの条件に変更
- `format_output` の出力から `ci_failing` キーを削除
- 関連するテスト・RBS シグネチャを更新

## Test plan

- [ ] `bundle exec rspec` がすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)