### PR TITLE
Fix matrix key resolution to support arbitrary matrix key names

### DIFF
--- a/lib/github/workflow_parser.rb
+++ b/lib/github/workflow_parser.rb
@@ -78,11 +78,10 @@ module GitHub
       return {} unless matrix.is_a?(Hash)
 
       result = {} #: Hash[String, Array[String]]
-      LANGUAGE_KEYS.each_key do |lang_key|
-        values = matrix[lang_key]
+      matrix.each do |key, values|
         next unless values.is_a?(Array)
 
-        result[lang_key] = values.map(&:to_s)
+        result[key] = values.map(&:to_s)
       end
       result
     end

--- a/spec/github/workflow_parser_spec.rb
+++ b/spec/github/workflow_parser_spec.rb
@@ -75,6 +75,37 @@ RSpec.describe GitHub::WorkflowParser do
       end
     end
 
+    context "when a workflow uses matrix build with 'ruby' key (not 'ruby-version')" do
+      let(:workflow_content) do
+        <<~YAML
+          jobs:
+            build:
+              strategy:
+                matrix:
+                  ruby: ['3.4.3']
+              steps:
+                - uses: ruby/setup-ruby@v1
+                  with:
+                    ruby-version: ${{ matrix.ruby }}
+        YAML
+      end
+      let(:entries) { [double(name: "main.yml", path: ".github/workflows/main.yml")] }
+      let(:file_entry) { double(content: Base64.encode64(workflow_content)) }
+
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_return(entries)
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/main.yml")
+          .and_return(file_entry)
+      end
+
+      it "returns the ruby version" do
+        expect(parser.language_versions).to eq({ "ruby" => ["3.4.3"] })
+      end
+    end
+
     context "when a workflow uses matrix build for ruby-version" do
       let(:workflow_content) do
         <<~YAML


### PR DESCRIPTION
## Summary

- `extract_matrix` previously only looked for `LANGUAGE_KEYS` names (`ruby-version` etc.) in the matrix
- Workflows using short key names like `ruby` with `${{ matrix.ruby }}` returned `ruby: []`
- Now all array-valued matrix keys are collected, enabling correct resolution of any matrix reference

## Test plan

- [x] Added test case covering `matrix.ruby` key style (e.g. `ruby-lsp-rbs-inline`)
- [x] All existing 10 tests pass (backward compatibility confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)