### PR TITLE
Add ruboclean to maintain .rubocop.yml in ASCII order

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,17 +1,16 @@
-# NOTE: Rules are sorted in ASCII order.
+---
+
+plugins:
+- rubocop-numbered-params
+- rubocop-rake
+- rubocop-rbs_inline
+- rubocop-rspec
 
 AllCops:
   NewCops: enable
   TargetRubyVersion: 4.0
   SuggestExtensions: false
 
-plugins:
-  - rubocop-numbered-params
-  - rubocop-rake
-  - rubocop-rbs_inline
-  - rubocop-rspec
-
-# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
   AllowSteepAnnotation: true
@@ -19,22 +18,20 @@ Layout/LeadingCommentSpace:
 Layout/LineLength:
   Max: 120
 
-# Metrics
 Metrics/AbcSize:
   Max: 20
 
 Metrics/MethodLength:
   Max: 30
 
-# RSpec
 RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10
-
-RSpec/MultipleExpectations:
-  Enabled: false
 
 RSpec/NamedSubject:
   Enabled: false
@@ -46,7 +43,6 @@ RSpec/SpecFilePathFormat:
   CustomTransform:
     GitHub: github
 
-# Style
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   gem "rbs"
   gem "rbs-inline"
   gem "rspec"
+  gem "ruboclean"
   gem "rubocop"
   gem "rubocop-numbered-params"
   gem "rubocop-rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
+    ruboclean (0.7.1)
     rubocop (1.86.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -177,6 +178,7 @@ DEPENDENCIES
   rbs
   rbs-inline
   rspec
+  ruboclean
   rubocop
   rubocop-numbered-params
   rubocop-rake
@@ -237,6 +239,7 @@ CHECKSUMS
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  ruboclean (0.7.1) sha256=4a97c8695706ee3b020b88aaf7cd59bc7ba69544dd140a937eec1623f4c17760
   rubocop (1.86.0) sha256=4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-numbered-params (1.0.0) sha256=6271a39c4751fb3e0b79b0aab26c407f2e4927aeef80c74622a6eaa373d7828a

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,12 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: :ci
 
-task ci: %i[rubocop spec steep]
+task ci: %i[ruboclean rubocop spec steep]
+
+desc "Check .rubocop.yml is sorted in ASCII order"
+task :ruboclean do
+  sh "bundle exec ruboclean --verify"
+end
 
 namespace :rbs do
   desc "Generate RBS files"


### PR DESCRIPTION
## Summary
- `ruboclean` gem を development 依存に追加
- `.rubocop.yml` が ASCII 順に整列されているかチェックする `ruboclean` rake タスクを追加
- `ci` タスクに `ruboclean` を組み込み、CI および pre-commit-check で自動実行されるように設定
- 既存の `.rubocop.yml` を ruboclean で整形（ASCII 順に並び替え、コメントは自動削除）

## Test plan
- [ ] `bundle exec rake ruboclean` が正常にパスすること
- [ ] `bundle exec rake ci` に ruboclean チェックが含まれること
- [ ] `.rubocop.yml` の並び順が崩れた場合に `rake ruboclean` が失敗すること

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)