### PR TITLE
Add url field to JSON output

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -89,6 +89,7 @@ module Ghscan
       repositories.map do |repo|
         {
           "name" => repo.name,
+          "url" => repo.url,
           "updated_at" => repo.updated_at.iso8601,
           "pull_requests_count" => repo.pull_requests_count,
           "language_versions" => repo.language_versions

--- a/lib/github/repository.rb
+++ b/lib/github/repository.rb
@@ -3,6 +3,7 @@
 module GitHub
   Repository = Data.define(
     :name,                 #: String
+    :url,                  #: String
     :updated_at,           #: Time
     :pull_requests_count,  #: Integer
     :language_versions     #: Hash[String, Array[String]]

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -42,7 +42,7 @@ module GitHub
     # @rbs total: Integer
     def build_repository(repo, index, total) #: GitHub::Repository
       warn "[debug] Processing #{repo.name} (#{index}/#{total})" if debug
-      Repository.new(name: repo.name, updated_at: repo.updated_at,
+      Repository.new(name: repo.name, url: repo.html_url, updated_at: repo.updated_at,
                      pull_requests_count: pull_requests_count(repo.name),
                      language_versions: language_versions(repo.name))
     end

--- a/sig/github/repository.rbs
+++ b/sig/github/repository.rbs
@@ -4,17 +4,19 @@ module GitHub
   class Repository < Data
     attr_reader name(): String
 
+    attr_reader url(): String
+
     attr_reader updated_at(): Time
 
     attr_reader pull_requests_count(): Integer
 
     attr_reader language_versions(): Hash[String, Array[String]]
 
-    def self.new: (String name, Time updated_at, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
-                | (name: String, updated_at: Time, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
+    def self.new: (String name, String url, Time updated_at, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
+                | (name: String, url: String, updated_at: Time, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
 
-    def self.members: () -> [ :name, :updated_at, :pull_requests_count, :language_versions ]
+    def self.members: () -> [ :name, :url, :updated_at, :pull_requests_count, :language_versions ]
 
-    def members: () -> [ :name, :updated_at, :pull_requests_count, :language_versions ]
+    def members: () -> [ :name, :url, :updated_at, :pull_requests_count, :language_versions ]
   end
 end

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -41,24 +41,29 @@ RSpec.describe Ghscan::Main do
       let(:repos) do
         [
           instance_double(GitHub::Repository,
-                          name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+                          name: "repo1", url: "https://github.com/testuser/repo1",
+                          updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 2,
                           language_versions: { "ruby" => ["3.2"] }),
           instance_double(GitHub::Repository,
-                          name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
+                          name: "repo2", url: "https://github.com/testuser/repo2",
+                          updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 0,
                           language_versions: {}),
           instance_double(GitHub::Repository,
-                          name: "repo3", updated_at: Time.new(2025, 9, 1, 0, 0, 0, "+00:00"),
+                          name: "repo3", url: "https://github.com/testuser/repo3",
+                          updated_at: Time.new(2025, 9, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 3,
                           language_versions: { "ruby" => ["3.3"] })
         ]
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
-        '[{"name":"repo1","updated_at":"2025-01-01T00:00:00+00:00",' \
+        '[{"name":"repo1","url":"https://github.com/testuser/repo1",' \
+          '"updated_at":"2025-01-01T00:00:00+00:00",' \
           '"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
-          '{"name":"repo3","updated_at":"2025-09-01T00:00:00+00:00",' \
+          '{"name":"repo3","url":"https://github.com/testuser/repo3",' \
+          '"updated_at":"2025-09-01T00:00:00+00:00",' \
           '"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
       end
 
@@ -282,11 +287,13 @@ RSpec.describe Ghscan::Main do
     let(:repos) do
       [
         instance_double(GitHub::Repository,
-                        name: "repo1", updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+                        name: "repo1", url: "https://github.com/testuser/repo1",
+                        updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
                         pull_requests_count: 2,
                         language_versions: { "ruby" => ["3.2"] }),
         instance_double(GitHub::Repository,
-                        name: "repo2", updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
+                        name: "repo2", url: "https://github.com/testuser/repo2",
+                        updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
                         pull_requests_count: 0,
                         language_versions: {})
       ]
@@ -295,10 +302,12 @@ RSpec.describe Ghscan::Main do
     it "returns an array of hashes with all repository attributes" do
       result = main.send(:format_output, repos)
       expect(result).to eq([
-                             { "name" => "repo1", "updated_at" => "2025-01-01T00:00:00+00:00",
+                             { "name" => "repo1", "url" => "https://github.com/testuser/repo1",
+                               "updated_at" => "2025-01-01T00:00:00+00:00",
                                "pull_requests_count" => 2,
                                "language_versions" => { "ruby" => ["3.2"] } },
-                             { "name" => "repo2", "updated_at" => "2025-06-01T00:00:00+00:00",
+                             { "name" => "repo2", "url" => "https://github.com/testuser/repo2",
+                               "updated_at" => "2025-06-01T00:00:00+00:00",
                                "pull_requests_count" => 0,
                                "language_versions" => {} }
                            ])

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe GitHub::RepositoryFetcher do
     context "when user has repositories" do
       let(:repos) do
         [
-          double(name: "repo1", updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
+          double(name: "repo1", html_url: "https://github.com/testuser/repo1",
+                 updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
                  default_branch: "main", archived: false, fork: false),
-          double(name: "repo2", updated_at: Time.new(2025, 6, 1), pushed_at: Time.now - (3 * 30 * 24 * 3600),
+          double(name: "repo2", html_url: "https://github.com/testuser/repo2",
+                 updated_at: Time.new(2025, 6, 1), pushed_at: Time.now - (3 * 30 * 24 * 3600),
                  default_branch: "master", archived: false, fork: false)
         ]
       end
@@ -42,9 +44,10 @@ RSpec.describe GitHub::RepositoryFetcher do
         expect(fetcher.repositories.length).to eq(2)
       end
 
-      it "sets repository name and updated_at correctly" do
+      it "sets repository name, url and updated_at correctly" do
         result = fetcher.repositories
         expect(result[0].name).to eq("repo1")
+        expect(result[0].url).to eq("https://github.com/testuser/repo1")
         expect(result[0].updated_at).to eq(Time.new(2025, 1, 1))
       end
 
@@ -61,7 +64,8 @@ RSpec.describe GitHub::RepositoryFetcher do
 
     context "when repository has language versions" do
       let(:repos) do
-        [double(name: "repo1", updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
+        [double(name: "repo1", html_url: "https://github.com/testuser/repo1",
+                updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
                 default_branch: "main", archived: false, fork: false)]
       end
       let(:parser_with_versions) do
@@ -94,19 +98,23 @@ RSpec.describe GitHub::RepositoryFetcher do
 
     context "when filtering repositories" do
       let(:active_repo) do
-        double(name: "active", updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+        double(name: "active", html_url: "https://github.com/testuser/active",
+               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: false, fork: false)
       end
       let(:archived_repo) do
-        double(name: "archived", updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+        double(name: "archived", html_url: "https://github.com/testuser/archived",
+               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: true, fork: false)
       end
       let(:forked_repo) do
-        double(name: "forked", updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+        double(name: "forked", html_url: "https://github.com/testuser/forked",
+               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: false, fork: true)
       end
       let(:old_repo) do
-        double(name: "old", updated_at: Time.now, pushed_at: Time.now - (2 * 365 * 24 * 3600),
+        double(name: "old", html_url: "https://github.com/testuser/old",
+               updated_at: Time.now, pushed_at: Time.now - (2 * 365 * 24 * 3600),
                default_branch: "main", archived: false, fork: false)
       end
 


### PR DESCRIPTION
## Summary

- `GitHub::Repository` データクラスに `url` フィールドを追加
- `RepositoryFetcher` で `repo.html_url`（Octokit の標準フィールド）を使って URL を設定
- `format_output` の JSON 出力に `"url"` キーを追加
- RBS シグネチャおよびテストを更新

Closes #28

## Test plan

- [ ] `bundle exec rspec` が全 45 テストパスすることを確認（ローカルで確認済み）
- [ ] 出力 JSON に `"url"` フィールドが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)