### PR TITLE
Remove updated_at attribute from Repository

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -90,7 +90,6 @@ module Ghscan
         {
           "name" => repo.name,
           "url" => repo.url,
-          "updated_at" => repo.updated_at.iso8601,
           "pull_requests_count" => repo.pull_requests_count,
           "language_versions" => repo.language_versions
         }

--- a/lib/github/repository.rb
+++ b/lib/github/repository.rb
@@ -4,7 +4,6 @@ module GitHub
   Repository = Data.define(
     :name,                 #: String
     :url,                  #: String
-    :updated_at,           #: Time
     :pull_requests_count,  #: Integer
     :language_versions     #: Hash[String, Array[String]]
   )

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -42,7 +42,7 @@ module GitHub
     # @rbs total: Integer
     def build_repository(repo, index, total) #: GitHub::Repository
       warn "[debug] Processing #{repo.name} (#{index}/#{total})" if debug
-      Repository.new(name: repo.name, url: repo.html_url, updated_at: repo.updated_at,
+      Repository.new(name: repo.name, url: repo.html_url,
                      pull_requests_count: pull_requests_count(repo.name),
                      language_versions: language_versions(repo.name))
     end

--- a/sig/github/repository.rbs
+++ b/sig/github/repository.rbs
@@ -6,17 +6,15 @@ module GitHub
 
     attr_reader url(): String
 
-    attr_reader updated_at(): Time
-
     attr_reader pull_requests_count(): Integer
 
     attr_reader language_versions(): Hash[String, Array[String]]
 
-    def self.new: (String name, String url, Time updated_at, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
-                | (name: String, url: String, updated_at: Time, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
+    def self.new: (String name, String url, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
+                | (name: String, url: String, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
 
-    def self.members: () -> [ :name, :url, :updated_at, :pull_requests_count, :language_versions ]
+    def self.members: () -> [ :name, :url, :pull_requests_count, :language_versions ]
 
-    def members: () -> [ :name, :url, :updated_at, :pull_requests_count, :language_versions ]
+    def members: () -> [ :name, :url, :pull_requests_count, :language_versions ]
   end
 end

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -42,17 +42,14 @@ RSpec.describe Ghscan::Main do
         [
           instance_double(GitHub::Repository,
                           name: "repo1", url: "https://github.com/testuser/repo1",
-                          updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 2,
                           language_versions: { "ruby" => ["3.2"] }),
           instance_double(GitHub::Repository,
                           name: "repo2", url: "https://github.com/testuser/repo2",
-                          updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 0,
                           language_versions: {}),
           instance_double(GitHub::Repository,
                           name: "repo3", url: "https://github.com/testuser/repo3",
-                          updated_at: Time.new(2025, 9, 1, 0, 0, 0, "+00:00"),
                           pull_requests_count: 3,
                           language_versions: { "ruby" => ["3.3"] })
         ]
@@ -60,10 +57,8 @@ RSpec.describe Ghscan::Main do
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
         '[{"name":"repo1","url":"https://github.com/testuser/repo1",' \
-          '"updated_at":"2025-01-01T00:00:00+00:00",' \
           '"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
           '{"name":"repo3","url":"https://github.com/testuser/repo3",' \
-          '"updated_at":"2025-09-01T00:00:00+00:00",' \
           '"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
       end
 
@@ -288,12 +283,10 @@ RSpec.describe Ghscan::Main do
       [
         instance_double(GitHub::Repository,
                         name: "repo1", url: "https://github.com/testuser/repo1",
-                        updated_at: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
                         pull_requests_count: 2,
                         language_versions: { "ruby" => ["3.2"] }),
         instance_double(GitHub::Repository,
                         name: "repo2", url: "https://github.com/testuser/repo2",
-                        updated_at: Time.new(2025, 6, 1, 0, 0, 0, "+00:00"),
                         pull_requests_count: 0,
                         language_versions: {})
       ]
@@ -303,11 +296,9 @@ RSpec.describe Ghscan::Main do
       result = main.send(:format_output, repos)
       expect(result).to eq([
                              { "name" => "repo1", "url" => "https://github.com/testuser/repo1",
-                               "updated_at" => "2025-01-01T00:00:00+00:00",
                                "pull_requests_count" => 2,
                                "language_versions" => { "ruby" => ["3.2"] } },
                              { "name" => "repo2", "url" => "https://github.com/testuser/repo2",
-                               "updated_at" => "2025-06-01T00:00:00+00:00",
                                "pull_requests_count" => 0,
                                "language_versions" => {} }
                            ])

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe GitHub::RepositoryFetcher do
       let(:repos) do
         [
           double(name: "repo1", html_url: "https://github.com/testuser/repo1",
-                 updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
+                 pushed_at: Time.now - (6 * 30 * 24 * 3600),
                  default_branch: "main", archived: false, fork: false),
           double(name: "repo2", html_url: "https://github.com/testuser/repo2",
-                 updated_at: Time.new(2025, 6, 1), pushed_at: Time.now - (3 * 30 * 24 * 3600),
+                 pushed_at: Time.now - (3 * 30 * 24 * 3600),
                  default_branch: "master", archived: false, fork: false)
         ]
       end
@@ -44,11 +44,10 @@ RSpec.describe GitHub::RepositoryFetcher do
         expect(fetcher.repositories.length).to eq(2)
       end
 
-      it "sets repository name, url and updated_at correctly" do
+      it "sets repository name and url correctly" do
         result = fetcher.repositories
         expect(result[0].name).to eq("repo1")
         expect(result[0].url).to eq("https://github.com/testuser/repo1")
-        expect(result[0].updated_at).to eq(Time.new(2025, 1, 1))
       end
 
       it "sets pull_requests_count correctly" do
@@ -65,7 +64,7 @@ RSpec.describe GitHub::RepositoryFetcher do
     context "when repository has language versions" do
       let(:repos) do
         [double(name: "repo1", html_url: "https://github.com/testuser/repo1",
-                updated_at: Time.new(2025, 1, 1), pushed_at: Time.now - (6 * 30 * 24 * 3600),
+                pushed_at: Time.now - (6 * 30 * 24 * 3600),
                 default_branch: "main", archived: false, fork: false)]
       end
       let(:parser_with_versions) do
@@ -99,22 +98,22 @@ RSpec.describe GitHub::RepositoryFetcher do
     context "when filtering repositories" do
       let(:active_repo) do
         double(name: "active", html_url: "https://github.com/testuser/active",
-               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+               pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: false, fork: false)
       end
       let(:archived_repo) do
         double(name: "archived", html_url: "https://github.com/testuser/archived",
-               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+               pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: true, fork: false)
       end
       let(:forked_repo) do
         double(name: "forked", html_url: "https://github.com/testuser/forked",
-               updated_at: Time.now, pushed_at: Time.now - (3 * 30 * 24 * 3600),
+               pushed_at: Time.now - (3 * 30 * 24 * 3600),
                default_branch: "main", archived: false, fork: true)
       end
       let(:old_repo) do
         double(name: "old", html_url: "https://github.com/testuser/old",
-               updated_at: Time.now, pushed_at: Time.now - (2 * 365 * 24 * 3600),
+               pushed_at: Time.now - (2 * 365 * 24 * 3600),
                default_branch: "main", archived: false, fork: false)
       end
 


### PR DESCRIPTION
## Summary

- `updated_at` 属性は現在コードベース内で使用されておらず、n8n ワークフロー側でも参照予定がないため削除
- `GitHub::Repository` Data クラス、型シグネチャ (RBS)、出力フォーマット、テストから完全に除去

## Changes

- `lib/github/repository.rb`: Data.define から `:updated_at` を削除
- `lib/github/repository_fetcher.rb`: `Repository.new` の引数から `updated_at:` を削除
- `lib/ghscan/main.rb`: `format_output` の JSON 出力から `updated_at` を削除
- `sig/github/repository.rbs`: 型シグネチャを更新
- `spec/github/repository_fetcher_spec.rb`: テストを更新
- `spec/ghscan/main_spec.rb`: テストと期待値を更新

## Test plan

- [x] `bundle exec rspec` — 45 examples, 0 failures
- [x] `bundle exec steep check` — No type error detected

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)