### PR TITLE
settings.json: gh:* を許可リストに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "WebFetch(domain:index.rubygems.org)",
       "WebFetch(domain:rubygems.org)",
       "WebFetch(domain:api.github.com)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "Bash(gh:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## 概要

Claude Code が gh コマンドを実行する際に毎回許可を求めてくる問題を解消するため、`.claude/settings.json` の `permissions.allow` に `Bash(gh:*)` を追加しました。

これにより、gh コマンドは確認なしで実行できるようになります。

## 関連イシュー

Closes #33