### PR TITLE
Add actionlint execution check to repository filtering

### DIFF
--- a/lib/ghscan/main.rb
+++ b/lib/ghscan/main.rb
@@ -61,7 +61,8 @@ module Ghscan
     def filter_repositories(repositories, latest_versions) #: Array[GitHub::Repository]
       repositories.select do |repo|
         repo.pull_requests_count >= 1 ||
-          outdated_language_version?(repo, latest_versions)
+          outdated_language_version?(repo, latest_versions) ||
+          !repo.uses_actionlint
       end
     end
 
@@ -91,7 +92,8 @@ module Ghscan
           "name" => repo.name,
           "url" => repo.url,
           "pull_requests_count" => repo.pull_requests_count,
-          "language_versions" => repo.language_versions
+          "language_versions" => repo.language_versions,
+          "uses_actionlint" => repo.uses_actionlint
         }
       end
     end

--- a/lib/github/repository.rb
+++ b/lib/github/repository.rb
@@ -5,6 +5,7 @@ module GitHub
     :name,                 #: String
     :url,                  #: String
     :pull_requests_count,  #: Integer
-    :language_versions     #: Hash[String, Array[String]]
+    :language_versions,    #: Hash[String, Array[String]]
+    :uses_actionlint       #: bool
   )
 end

--- a/lib/github/repository_fetcher.rb
+++ b/lib/github/repository_fetcher.rb
@@ -42,9 +42,11 @@ module GitHub
     # @rbs total: Integer
     def build_repository(repo, index, total) #: GitHub::Repository
       warn "[debug] Processing #{repo.name} (#{index}/#{total})" if debug
+      parser = workflow_parser(repo.name)
       Repository.new(name: repo.name, url: repo.html_url,
                      pull_requests_count: pull_requests_count(repo.name),
-                     language_versions: language_versions(repo.name))
+                     language_versions: parser.language_versions,
+                     uses_actionlint: parser.uses_actionlint?)
     end
 
     # @rbs repo_name: String
@@ -53,8 +55,8 @@ module GitHub
     end
 
     # @rbs repo_name: String
-    def language_versions(repo_name) #: Hash[String, Array[String]]
-      WorkflowParser.new(client:, repo_full_name: "#{login}/#{repo_name}").language_versions
+    def workflow_parser(repo_name) #: GitHub::WorkflowParser
+      WorkflowParser.new(client:, repo_full_name: "#{login}/#{repo_name}")
     end
   end
 end

--- a/lib/github/workflow_parser.rb
+++ b/lib/github/workflow_parser.rb
@@ -13,6 +13,7 @@ module GitHub
     }.freeze #: Hash[String, String]
 
     MATRIX_REF_PATTERN = /\A\$\{\{\s*matrix\.([\w-]+)\s*\}\}\z/ #: Regexp
+    # @rbs @workflow_files: Array[String]
 
     # @rbs client: Octokit::Client
     # @rbs repo_full_name: String
@@ -23,16 +24,24 @@ module GitHub
 
     def language_versions #: Hash[String, Array[String]]
       versions = {} #: Hash[String, Array[String]]
-      fetch_workflow_files.each do |content|
+      workflow_files.each do |content|
         extract_from_workflow(content, versions)
       end
       versions.transform_values(&:uniq)
+    end
+
+    def uses_actionlint? #: bool
+      workflow_files.any? { _1.match?(/\bactionlint\b/) }
     end
 
     private
 
     attr_reader :client #: Octokit::Client
     attr_reader :repo_full_name #: String
+
+    def workflow_files #: Array[String]
+      @workflow_files ||= fetch_workflow_files
+    end
 
     def fetch_workflow_files #: Array[String]
       entries = client.contents(repo_full_name, path: ".github/workflows")

--- a/sig/github/repository.rbs
+++ b/sig/github/repository.rbs
@@ -10,11 +10,13 @@ module GitHub
 
     attr_reader language_versions(): Hash[String, Array[String]]
 
-    def self.new: (String name, String url, Integer pull_requests_count, Hash[String, Array[String]] language_versions) -> instance
-                | (name: String, url: String, pull_requests_count: Integer, language_versions: Hash[String, Array[String]]) -> instance
+    attr_reader uses_actionlint(): bool
 
-    def self.members: () -> [ :name, :url, :pull_requests_count, :language_versions ]
+    def self.new: (String name, String url, Integer pull_requests_count, Hash[String, Array[String]] language_versions, bool uses_actionlint) -> instance
+                | (name: String, url: String, pull_requests_count: Integer, language_versions: Hash[String, Array[String]], uses_actionlint: bool) -> instance
 
-    def members: () -> [ :name, :url, :pull_requests_count, :language_versions ]
+    def self.members: () -> [ :name, :url, :pull_requests_count, :language_versions, :uses_actionlint ]
+
+    def members: () -> [ :name, :url, :pull_requests_count, :language_versions, :uses_actionlint ]
   end
 end

--- a/sig/github/repository_fetcher.rbs
+++ b/sig/github/repository_fetcher.rbs
@@ -27,6 +27,6 @@ module GitHub
     def pull_requests_count: (String repo_name) -> Integer
 
     # @rbs repo_name: String
-    def language_versions: (String repo_name) -> Hash[String, Array[String]]
+    def workflow_parser: (String repo_name) -> GitHub::WorkflowParser
   end
 end

--- a/sig/github/workflow_parser.rbs
+++ b/sig/github/workflow_parser.rbs
@@ -6,17 +6,23 @@ module GitHub
 
     MATRIX_REF_PATTERN: Regexp
 
+    @workflow_files: Array[String]
+
     # @rbs client: Octokit::Client
     # @rbs repo_full_name: String
     def initialize: (client: Octokit::Client, repo_full_name: String) -> void
 
     def language_versions: () -> Hash[String, Array[String]]
 
+    def uses_actionlint?: () -> bool
+
     private
 
     attr_reader client: Octokit::Client
 
     attr_reader repo_full_name: String
+
+    def workflow_files: () -> Array[String]
 
     def fetch_workflow_files: () -> Array[String]
 

--- a/spec/ghscan/main_spec.rb
+++ b/spec/ghscan/main_spec.rb
@@ -43,23 +43,26 @@ RSpec.describe Ghscan::Main do
           instance_double(GitHub::Repository,
                           name: "repo1", url: "https://github.com/testuser/repo1",
                           pull_requests_count: 2,
-                          language_versions: { "ruby" => ["3.2"] }),
+                          language_versions: { "ruby" => ["3.2"] },
+                          uses_actionlint: true),
           instance_double(GitHub::Repository,
                           name: "repo2", url: "https://github.com/testuser/repo2",
                           pull_requests_count: 0,
-                          language_versions: {}),
+                          language_versions: {},
+                          uses_actionlint: true),
           instance_double(GitHub::Repository,
                           name: "repo3", url: "https://github.com/testuser/repo3",
                           pull_requests_count: 3,
-                          language_versions: { "ruby" => ["3.3"] })
+                          language_versions: { "ruby" => ["3.3"] },
+                          uses_actionlint: true)
         ]
       end
       let(:fetcher) { instance_double(GitHub::RepositoryFetcher, repositories: repos) }
       let(:expected_json) do
         '[{"name":"repo1","url":"https://github.com/testuser/repo1",' \
-          '"pull_requests_count":2,"language_versions":{"ruby":["3.2"]}},' \
+          '"pull_requests_count":2,"language_versions":{"ruby":["3.2"]},"uses_actionlint":true},' \
           '{"name":"repo3","url":"https://github.com/testuser/repo3",' \
-          '"pull_requests_count":3,"language_versions":{"ruby":["3.3"]}}]'
+          '"pull_requests_count":3,"language_versions":{"ruby":["3.3"]},"uses_actionlint":true}]'
       end
 
       before do
@@ -153,10 +156,14 @@ RSpec.describe Ghscan::Main do
     let(:latest_versions) { { "ruby" => [4, 0], "node" => [22, 14], "python" => [3, 13] } }
     let(:repos) do
       [
-        instance_double(GitHub::Repository, name: "repo1", pull_requests_count: 0, language_versions: {}),
-        instance_double(GitHub::Repository, name: "repo2", pull_requests_count: 2, language_versions: {}),
-        instance_double(GitHub::Repository, name: "repo3", pull_requests_count: 0, language_versions: {}),
-        instance_double(GitHub::Repository, name: "repo4", pull_requests_count: 3, language_versions: {})
+        instance_double(GitHub::Repository,
+                        name: "repo1", pull_requests_count: 0, language_versions: {}, uses_actionlint: true),
+        instance_double(GitHub::Repository,
+                        name: "repo2", pull_requests_count: 2, language_versions: {}, uses_actionlint: true),
+        instance_double(GitHub::Repository,
+                        name: "repo3", pull_requests_count: 0, language_versions: {}, uses_actionlint: true),
+        instance_double(GitHub::Repository,
+                        name: "repo4", pull_requests_count: 3, language_versions: {}, uses_actionlint: true)
       ]
     end
 
@@ -168,7 +175,8 @@ RSpec.describe Ghscan::Main do
     context "when a repository uses an outdated language version" do
       let(:outdated_repo) do
         instance_double(GitHub::Repository, name: "outdated",
-                                            pull_requests_count: 0, language_versions: { "ruby" => ["3.2"] })
+                                            pull_requests_count: 0, language_versions: { "ruby" => ["3.2"] },
+                                            uses_actionlint: true)
       end
 
       it "includes the repository in the result" do
@@ -180,11 +188,38 @@ RSpec.describe Ghscan::Main do
     context "when a repository uses the latest language version" do
       let(:current_repo) do
         instance_double(GitHub::Repository, name: "current",
-                                            pull_requests_count: 0, language_versions: { "ruby" => ["4.0"] })
+                                            pull_requests_count: 0, language_versions: { "ruby" => ["4.0"] },
+                                            uses_actionlint: true)
       end
 
       it "excludes the repository from the result" do
         result = main.send(:filter_repositories, [current_repo], latest_versions)
+        expect(result).to be_empty
+      end
+    end
+
+    context "when a repository does not run actionlint" do
+      let(:no_actionlint_repo) do
+        instance_double(GitHub::Repository, name: "no-actionlint",
+                                            pull_requests_count: 0, language_versions: { "ruby" => ["4.0"] },
+                                            uses_actionlint: false)
+      end
+
+      it "includes the repository in the result" do
+        result = main.send(:filter_repositories, [no_actionlint_repo], latest_versions)
+        expect(result.map(&:name)).to eq(["no-actionlint"])
+      end
+    end
+
+    context "when a repository runs actionlint" do
+      let(:with_actionlint_repo) do
+        instance_double(GitHub::Repository, name: "with-actionlint",
+                                            pull_requests_count: 0, language_versions: { "ruby" => ["4.0"] },
+                                            uses_actionlint: true)
+      end
+
+      it "excludes the repository from the result (when no other conditions match)" do
+        result = main.send(:filter_repositories, [with_actionlint_repo], latest_versions)
         expect(result).to be_empty
       end
     end
@@ -284,11 +319,13 @@ RSpec.describe Ghscan::Main do
         instance_double(GitHub::Repository,
                         name: "repo1", url: "https://github.com/testuser/repo1",
                         pull_requests_count: 2,
-                        language_versions: { "ruby" => ["3.2"] }),
+                        language_versions: { "ruby" => ["3.2"] },
+                        uses_actionlint: true),
         instance_double(GitHub::Repository,
                         name: "repo2", url: "https://github.com/testuser/repo2",
                         pull_requests_count: 0,
-                        language_versions: {})
+                        language_versions: {},
+                        uses_actionlint: false)
       ]
     end
 
@@ -297,10 +334,12 @@ RSpec.describe Ghscan::Main do
       expect(result).to eq([
                              { "name" => "repo1", "url" => "https://github.com/testuser/repo1",
                                "pull_requests_count" => 2,
-                               "language_versions" => { "ruby" => ["3.2"] } },
+                               "language_versions" => { "ruby" => ["3.2"] },
+                               "uses_actionlint" => true },
                              { "name" => "repo2", "url" => "https://github.com/testuser/repo2",
                                "pull_requests_count" => 0,
-                               "language_versions" => {} }
+                               "language_versions" => {},
+                               "uses_actionlint" => false }
                            ])
     end
 

--- a/spec/github/repository_fetcher_spec.rb
+++ b/spec/github/repository_fetcher_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GitHub::RepositoryFetcher do
 
   let(:client) { instance_double(Octokit::Client) }
   let(:user) { double(login: "testuser") }
-  let(:workflow_parser) { instance_double(GitHub::WorkflowParser, language_versions: {}) }
+  let(:workflow_parser) { instance_double(GitHub::WorkflowParser, language_versions: {}, uses_actionlint?: false) }
 
   before do
     allow(client).to receive(:user).and_return(user)
@@ -68,7 +68,8 @@ RSpec.describe GitHub::RepositoryFetcher do
                 default_branch: "main", archived: false, fork: false)]
       end
       let(:parser_with_versions) do
-        instance_double(GitHub::WorkflowParser, language_versions: { "ruby" => ["3.1", "3.2"] })
+        instance_double(GitHub::WorkflowParser,
+                        language_versions: { "ruby" => ["3.1", "3.2"] }, uses_actionlint?: false)
       end
 
       before do

--- a/spec/github/workflow_parser_spec.rb
+++ b/spec/github/workflow_parser_spec.rb
@@ -8,6 +8,142 @@ RSpec.describe GitHub::WorkflowParser do
 
   let(:client) { instance_double(Octokit::Client) }
 
+  describe "#uses_actionlint?" do
+    context "when .github/workflows/ does not exist" do
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_raise(Octokit::NotFound)
+      end
+
+      it "returns false" do
+        expect(parser.uses_actionlint?).to be false
+      end
+    end
+
+    context "when workflow runs actionlint via run: step" do
+      let(:workflow_content) do
+        <<~YAML
+          jobs:
+            lint:
+              steps:
+                - uses: actions/checkout@v4
+                - run: actionlint
+        YAML
+      end
+      let(:entries) { [double(name: "ci.yml", path: ".github/workflows/ci.yml")] }
+      let(:file_entry) { double(content: Base64.encode64(workflow_content)) }
+
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_return(entries)
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/ci.yml")
+          .and_return(file_entry)
+      end
+
+      it "returns true" do
+        expect(parser.uses_actionlint?).to be true
+      end
+    end
+
+    context "when workflow uses actionlint via uses: action" do
+      let(:workflow_content) do
+        <<~YAML
+          jobs:
+            lint:
+              steps:
+                - uses: actions/checkout@v4
+                - uses: rhysd/action-actionlint@v1
+        YAML
+      end
+      let(:entries) { [double(name: "ci.yml", path: ".github/workflows/ci.yml")] }
+      let(:file_entry) { double(content: Base64.encode64(workflow_content)) }
+
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_return(entries)
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/ci.yml")
+          .and_return(file_entry)
+      end
+
+      it "returns true" do
+        expect(parser.uses_actionlint?).to be true
+      end
+    end
+
+    context "when workflow does not run actionlint" do
+      let(:workflow_content) do
+        <<~YAML
+          jobs:
+            test:
+              steps:
+                - uses: actions/checkout@v4
+                - run: bundle exec rspec
+        YAML
+      end
+      let(:entries) { [double(name: "ci.yml", path: ".github/workflows/ci.yml")] }
+      let(:file_entry) { double(content: Base64.encode64(workflow_content)) }
+
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_return(entries)
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/ci.yml")
+          .and_return(file_entry)
+      end
+
+      it "returns false" do
+        expect(parser.uses_actionlint?).to be false
+      end
+    end
+
+    context "when actionlint is run in one of multiple workflow files" do
+      let(:ci_content) do
+        <<~YAML
+          jobs:
+            test:
+              steps:
+                - run: bundle exec rspec
+        YAML
+      end
+      let(:lint_content) do
+        <<~YAML
+          jobs:
+            lint:
+              steps:
+                - run: actionlint
+        YAML
+      end
+      let(:entries) do
+        [
+          double(name: "ci.yml", path: ".github/workflows/ci.yml"),
+          double(name: "lint.yml", path: ".github/workflows/lint.yml")
+        ]
+      end
+
+      before do
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows")
+          .and_return(entries)
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/ci.yml")
+          .and_return(double(content: Base64.encode64(ci_content)))
+        allow(client).to receive(:contents)
+          .with("testuser/repo1", path: ".github/workflows/lint.yml")
+          .and_return(double(content: Base64.encode64(lint_content)))
+      end
+
+      it "returns true" do
+        expect(parser.uses_actionlint?).to be true
+      end
+    end
+  end
+
   describe "#language_versions" do
     context "when .github/workflows/ does not exist" do
       before do


### PR DESCRIPTION
## 概要

各リポジトリの CI ワークフローで actionlint を実行しているかどうかを検出し、実行していないリポジトリをフィルタ結果に含めるようにしました。

主な変更点:
- `WorkflowParser` に `runs_actionlint?` メソッドを追加（`run:` ステップや `uses:` アクションで actionlint の実行を検知）
- `Repository` に `runs_actionlint` フィールドを追加
- `RepositoryFetcher` でワークフローパーサーを再利用して `runs_actionlint` を取得
- `filter_repositories` に「actionlint を実行していないリポジトリは表示する」条件を追加
- JSON 出力に `runs_actionlint` フィールドを追加
- ワークフローファイルを同一インスタンス内でキャッシュし、`language_versions` と `runs_actionlint?` の両方を呼んでも API を1回だけ呼ぶよう改善

## 関連イシュー

Closes #36