### PR TITLE
process-github-issue スキルでブランチ作成前に git fetch を実行する

### DIFF
--- a/.claude/skills/process-github-issue/SKILL.md
+++ b/.claude/skills/process-github-issue/SKILL.md
@@ -48,8 +48,11 @@ gh issue edit <issue-number> --add-label "processing"
 - slug: イシュータイトルから生成（英小文字・数字・ハイフンのみ、連続ハイフンを1つに、最大 40 文字）
 - 例: issue-42-add-user-authentication
 
-# ブランチを main から作成
-git branch issue-<number>-<slug> main
+# リモートリポジトリの最新情報を取得
+git fetch origin
+
+# ブランチを origin/main から作成
+git branch issue-<number>-<slug> origin/main
 
 # worktree を作成
 git worktree add .claude/worktrees/issue-<number> issue-<number>-<slug>


### PR DESCRIPTION
## 概要

`process-github-issue` スキルの Step 3 を改善し、作業ブランチを作成する前に `git fetch origin` を実行するようにしました。また、ブランチの起点を `main`（ローカル）から `origin/main`（リモートの最新）に変更しました。

### 変更内容

- ブランチ作成前に `git fetch origin` を実行して最新状態を取得
- `git branch issue-<number>-<slug> main` → `git branch issue-<number>-<slug> origin/main` に変更

### 効果

- 連続してタスクを処理する場合でも、前のコミットが残った状態で作業することを防止
- リポジトリ側で別の作業が進んでいる場合にも、常に最新の `main` から作業を開始できる

## 関連イシュー

Closes #35