### PR TITLE
process-github-issue スキルで git -C オプションを使用する

### DIFF
--- a/.claude/skills/process-github-issue/SKILL.md
+++ b/.claude/skills/process-github-issue/SKILL.md
@@ -61,6 +61,22 @@ git worktree add .claude/worktrees/issue-<number> issue-<number>-<slug>
 
 worktree 内（.claude/worktrees/issue-<number>）で作業する。
 イシューの内容に従って実装し、変更をコミットする。
+
+### git 操作の注意事項
+
+worktree 内での git 操作は `git -C` オプションを使用し、`cd` を使わずに行うこと:
+
+```
+# 良い例: git -C でパスを指定
+git -C .claude/worktrees/issue-<number> add <file>
+git -C .claude/worktrees/issue-<number> commit -m "..."
+
+# 悪い例: cd && git の組み合わせ（sandbox モードで確認が増える）
+cd .claude/worktrees/issue-<number> && git add <file>
+```
+
+また、必要な場合を除き `&&` によるコマンドの連結も避けること。
+
 コミットメッセージの末尾には必ず以下を含めること:
 
 Closes #<issue-number>


### PR DESCRIPTION
## 概要

worktree 内での git 操作において、`cd ... && git ...` パターンの代わりに `git -C` オプションを使用するよう、`process-github-issue` スキル定義を更新した。

Claude Code の sandbox モードでは `cd ... && git ...` が composite command とみなされ、開発者への確認が増えてワークフローの効率が下がる問題があった。`git -C` オプションを使用することで `cd` を使わずに worktree 内の git 操作が可能になる。

また、必要な場合を除き `&&` によるコマンド連結も避けるよう注意事項を追記した。

## 関連イシュー

Closes #39