### PR TITLE
Add twcheck CLI command to emit new posts from X (Twitter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 GITHUB_TOKEN=your_token_here
 GHOME_IP=192.168.1.100
+X_BEARER_TOKEN=your_bearer_token_here

--- a/src/twcheck/cli.ts
+++ b/src/twcheck/cli.ts
@@ -1,0 +1,11 @@
+import "dotenv/config";
+import { parseArgs, run } from "./main.js";
+
+run(parseArgs(process.argv))
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/twcheck/main.ts
+++ b/src/twcheck/main.ts
@@ -1,0 +1,316 @@
+import { parseArgs as nodeParseArgs } from "node:util";
+import type { AccountRunResult, TwcheckState } from "./state.js";
+import { DEFAULT_STATE_PATH, getAccountState, loadState, mergeStateAfterRun, saveState } from "./state.js";
+import type { FetchUserTweetsOptions, XClientApi, XError, XTweet, XUser } from "./xClient.js";
+import { XClient } from "./xClient.js";
+
+export interface RunOptions {
+  usernames: string[];
+  statePath: string;
+  includeRetweets: boolean;
+  includeReplies: boolean;
+}
+
+export interface AuthorInfo {
+  id: string;
+  username: string;
+  name: string;
+  profile_image_url: string | null;
+}
+
+export interface MediaInfo {
+  type: string;
+  url: string | null;
+  preview_image_url: string | null;
+}
+
+export interface UrlInfo {
+  url: string;
+  expanded_url: string;
+  display_url: string;
+}
+
+export interface PostEntry {
+  id: string;
+  url: string;
+  text: string;
+  created_at: string;
+  lang: string | null;
+  media: MediaInfo[];
+  urls: UrlInfo[];
+  author: AuthorInfo;
+  retweeted_by: AuthorInfo | null;
+}
+
+export interface ErrorEntry {
+  username: string;
+  code: XError["code"];
+  message: string;
+  reset_at?: string;
+}
+
+export interface RunSummary {
+  total_accounts: number;
+  baseline_established: number;
+  total_posts: number;
+  errors: number;
+}
+
+export interface RunOutput {
+  checked_at: string;
+  posts: PostEntry[];
+  errors: ErrorEntry[];
+  summary: RunSummary;
+}
+
+export function parseArgs(argv: string[]): RunOptions {
+  const { values, positionals } = nodeParseArgs({
+    args: argv.slice(2),
+    options: {
+      state: { type: "string" },
+      "include-retweets": { type: "boolean" },
+      "include-replies": { type: "boolean" },
+    },
+    allowPositionals: true,
+  });
+
+  return {
+    usernames: positionals.map((u) => u.replace(/^@/, "")),
+    statePath: values.state ?? DEFAULT_STATE_PATH,
+    includeRetweets: values["include-retweets"] ?? false,
+    includeReplies: values["include-replies"] ?? false,
+  };
+}
+
+export function requireBearerToken(): string {
+  const token = process.env.X_BEARER_TOKEN;
+  if (!token) {
+    console.error("Error: X_BEARER_TOKEN environment variable is not set");
+    process.exit(1);
+  }
+  return token;
+}
+
+export function buildPostEntry(tweet: XTweet): PostEntry {
+  return {
+    id: tweet.id,
+    url: `https://x.com/${encodeURIComponent(tweet.author.username)}/status/${tweet.sourceTweetId}`,
+    text: tweet.text,
+    created_at: tweet.createdAt,
+    lang: tweet.lang,
+    media: tweet.media.map((m) => ({
+      type: m.type,
+      url: m.url,
+      preview_image_url: m.previewImageUrl,
+    })),
+    urls: tweet.urls.map((u) => ({
+      url: u.url,
+      expanded_url: u.expandedUrl,
+      display_url: u.displayUrl,
+    })),
+    author: toAuthorInfo(tweet.author),
+    retweeted_by: tweet.retweetedBy ? toAuthorInfo(tweet.retweetedBy) : null,
+  };
+}
+
+function toAuthorInfo(user: XUser): AuthorInfo {
+  return {
+    id: user.id,
+    username: user.username,
+    name: user.name,
+    profile_image_url: user.profileImageUrl,
+  };
+}
+
+export function sortPostsChronologically(posts: PostEntry[]): PostEntry[] {
+  return [...posts].sort((a, b) => {
+    const ta = Date.parse(a.created_at);
+    const tb = Date.parse(b.created_at);
+    if (ta !== tb) return ta - tb;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function buildRunOutput(
+  checkedAt: Date,
+  accountsCount: number,
+  baselineEstablishedCount: number,
+  posts: PostEntry[],
+  errors: ErrorEntry[],
+): RunOutput {
+  const sorted = sortPostsChronologically(posts);
+  return {
+    checked_at: checkedAt.toISOString(),
+    posts: sorted,
+    errors,
+    summary: {
+      total_accounts: accountsCount,
+      baseline_established: baselineEstablishedCount,
+      total_posts: sorted.length,
+      errors: errors.length,
+    },
+  };
+}
+
+interface ProcessedAccount {
+  accountResult: AccountRunResult;
+  posts: PostEntry[];
+  errorEntry: ErrorEntry | null;
+  baselineEstablished: boolean;
+}
+
+export async function processAccount(
+  username: string,
+  user: XUser,
+  state: TwcheckState,
+  client: XClientApi,
+  options: Pick<RunOptions, "includeRetweets" | "includeReplies">,
+): Promise<ProcessedAccount> {
+  const previous = getAccountState(state, username);
+  const isFirstRun = !previous || previous.lastSeenId === null;
+
+  const fetchOptions: FetchUserTweetsOptions = {
+    includeRetweets: options.includeRetweets,
+    includeReplies: options.includeReplies,
+  };
+
+  if (isFirstRun) {
+    // Baseline run: fetch only the most recent tweet to record as lastSeenId.
+    fetchOptions.maxResults = 5;
+    fetchOptions.maxPages = 1;
+  } else {
+    fetchOptions.sinceId = previous?.lastSeenId ?? null;
+  }
+
+  const result = await client.fetchUserTweets(user.id, fetchOptions);
+
+  if (!result.ok) {
+    return {
+      accountResult: { username, status: "error" },
+      posts: [],
+      errorEntry: {
+        username,
+        code: result.error.code,
+        message: result.error.message,
+        ...(result.error.resetAt ? { reset_at: result.error.resetAt } : {}),
+      },
+      baselineEstablished: false,
+    };
+  }
+
+  const tweets = result.tweets;
+
+  if (isFirstRun) {
+    const newestId = tweets[0]?.id ?? null;
+    return {
+      accountResult: { username, status: "baseline_established", newLastSeenId: newestId },
+      posts: [],
+      errorEntry: null,
+      baselineEstablished: true,
+    };
+  }
+
+  const newestId = tweets[0]?.id ?? previous?.lastSeenId ?? null;
+
+  return {
+    accountResult: { username, status: "ok", newLastSeenId: newestId },
+    posts: tweets.map((tweet) => buildPostEntry(tweet)),
+    errorEntry: null,
+    baselineEstablished: false,
+  };
+}
+
+export async function run(options: RunOptions): Promise<void> {
+  if (options.usernames.length === 0) {
+    console.error(
+      JSON.stringify({
+        error: "No usernames specified. Usage: twcheck [options] <username1> [username2 ...]",
+      }),
+    );
+    process.exit(1);
+  }
+
+  const bearerToken = requireBearerToken();
+  const client = new XClient(bearerToken);
+  const state = await loadState(options.statePath);
+  const now = new Date();
+
+  const lookup = await client.lookupUsers(options.usernames);
+  const posts: PostEntry[] = [];
+  const errors: ErrorEntry[] = [];
+  const accountResults: AccountRunResult[] = [];
+  let baselineEstablishedCount = 0;
+
+  if (!lookup.ok) {
+    // Global failure during user lookup — no per-account processing possible.
+    for (const username of options.usernames) {
+      errors.push({
+        username,
+        code: lookup.error.code,
+        message: lookup.error.message,
+        ...(lookup.error.resetAt ? { reset_at: lookup.error.resetAt } : {}),
+      });
+    }
+    const output = buildRunOutput(now, options.usernames.length, 0, posts, errors);
+    console.log(JSON.stringify(output));
+    process.exit(1);
+  }
+
+  const { found, missing } = lookup.result;
+
+  for (const username of missing) {
+    errors.push({
+      username,
+      code: "account_not_found",
+      message: `user "${username}" not found`,
+    });
+    accountResults.push({ username, status: "error" });
+  }
+
+  const tasks = options.usernames
+    .map((u) => {
+      const key = u.toLowerCase();
+      const user = found.get(key);
+      if (!user) return null;
+      return { username: u, user };
+    })
+    .filter((t): t is { username: string; user: XUser } => t !== null);
+
+  const settled = await Promise.allSettled(
+    tasks.map((t) => processAccount(t.username, t.user, state, client, options)),
+  );
+
+  for (let i = 0; i < settled.length; i += 1) {
+    const s = settled[i];
+    const username = tasks[i].username;
+    if (s.status === "fulfilled") {
+      accountResults.push(s.value.accountResult);
+      posts.push(...s.value.posts);
+      if (s.value.errorEntry) {
+        errors.push(s.value.errorEntry);
+      }
+      if (s.value.baselineEstablished) {
+        baselineEstablishedCount += 1;
+      }
+    } else {
+      accountResults.push({ username, status: "error" });
+      errors.push({
+        username,
+        code: "fetch_failed",
+        message: s.reason instanceof Error ? s.reason.message : String(s.reason),
+      });
+    }
+  }
+
+  const output = buildRunOutput(now, options.usernames.length, baselineEstablishedCount, posts, errors);
+
+  const nextState = mergeStateAfterRun(state, accountResults, now);
+  await saveState(nextState, options.statePath);
+
+  console.log(JSON.stringify(output));
+
+  const anySuccess = accountResults.some((r) => r.status !== "error");
+  if (!anySuccess) {
+    process.exit(1);
+  }
+}

--- a/src/twcheck/state.ts
+++ b/src/twcheck/state.ts
@@ -1,0 +1,120 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+export const DEFAULT_STATE_PATH = "./twcheck_state.json";
+export const STATE_VERSION = 1;
+
+export interface AccountState {
+  lastSeenId: string | null;
+  lastCheckedAt: string;
+}
+
+export interface TwcheckState {
+  version: typeof STATE_VERSION;
+  accounts: Record<string, AccountState>;
+}
+
+export interface AccountRunResult {
+  username: string;
+  status: "ok" | "baseline_established" | "error";
+  newLastSeenId?: string | null;
+}
+
+export function emptyState(): TwcheckState {
+  return { version: STATE_VERSION, accounts: {} };
+}
+
+export function resolveStatePath(path: string): string {
+  return isAbsolute(path) ? path : resolve(process.cwd(), path);
+}
+
+export async function loadState(path: string = DEFAULT_STATE_PATH): Promise<TwcheckState> {
+  const absolute = resolveStatePath(path);
+  let raw: string;
+  try {
+    raw = await readFile(absolute, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return emptyState();
+    }
+    console.warn(`[twcheck] failed to read state at ${absolute}: ${(error as Error).message}`);
+    return emptyState();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`[twcheck] state file is not valid JSON, starting fresh: ${(error as Error).message}`);
+    return emptyState();
+  }
+
+  if (!isTwcheckState(parsed)) {
+    console.warn("[twcheck] state file schema is invalid or version mismatch, starting fresh");
+    return emptyState();
+  }
+  return parsed;
+}
+
+export async function saveState(state: TwcheckState, path: string = DEFAULT_STATE_PATH): Promise<void> {
+  const absolute = resolveStatePath(path);
+  const dir = dirname(absolute);
+  await mkdir(dir, { recursive: true });
+
+  const tmp = `${absolute}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await rename(tmp, absolute);
+}
+
+export function mergeStateAfterRun(
+  state: TwcheckState,
+  results: readonly AccountRunResult[],
+  now: Date = new Date(),
+): TwcheckState {
+  const nowIso = now.toISOString();
+  const accounts: Record<string, AccountState> = { ...state.accounts };
+
+  for (const result of results) {
+    if (result.status === "error") {
+      continue;
+    }
+    const key = result.username.toLowerCase();
+    const previous = accounts[key];
+    accounts[key] = {
+      lastSeenId: result.newLastSeenId ?? previous?.lastSeenId ?? null,
+      lastCheckedAt: nowIso,
+    };
+  }
+
+  return { version: STATE_VERSION, accounts };
+}
+
+export function getAccountState(state: TwcheckState, username: string): AccountState | undefined {
+  return state.accounts[username.toLowerCase()];
+}
+
+function isTwcheckState(value: unknown): value is TwcheckState {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as { version?: unknown; accounts?: unknown };
+  if (candidate.version !== STATE_VERSION) {
+    return false;
+  }
+  if (typeof candidate.accounts !== "object" || candidate.accounts === null) {
+    return false;
+  }
+  for (const entry of Object.values(candidate.accounts as Record<string, unknown>)) {
+    if (typeof entry !== "object" || entry === null) {
+      return false;
+    }
+    const acc = entry as { lastSeenId?: unknown; lastCheckedAt?: unknown };
+    if (acc.lastSeenId !== null && typeof acc.lastSeenId !== "string") {
+      return false;
+    }
+    if (typeof acc.lastCheckedAt !== "string") {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/twcheck/xClient.ts
+++ b/src/twcheck/xClient.ts
@@ -1,0 +1,440 @@
+export const X_API_BASE = "https://api.x.com/2";
+export const DEFAULT_PAGE_SIZE = 100;
+export const DEFAULT_MAX_PAGES = 5;
+export const USER_LOOKUP_BATCH_SIZE = 100;
+
+export type XErrorCode = "unauthorized" | "account_not_found" | "rate_limited" | "fetch_failed";
+
+export interface XError {
+  code: XErrorCode;
+  message: string;
+  resetAt?: string;
+}
+
+export interface XUser {
+  id: string;
+  username: string;
+  name: string;
+  profileImageUrl: string | null;
+}
+
+export interface XUserLookup {
+  found: Map<string, XUser>; // key = lowercase username
+  missing: string[]; // lowercase usernames
+}
+
+export interface XMediaEntry {
+  type: string;
+  url: string | null;
+  previewImageUrl: string | null;
+  mediaKey: string;
+}
+
+export interface XUrlEntry {
+  url: string; // the t.co URL as it appears in the tweet text
+  expandedUrl: string; // the fully expanded destination URL
+  displayUrl: string; // the display-friendly URL shown in clients
+}
+
+export interface XTweet {
+  id: string;
+  sourceTweetId: string; // original tweet id; same as `id` unless this is a retweet
+  text: string;
+  createdAt: string;
+  lang: string | null;
+  author: XUser; // effective author: for retweets this is the original poster
+  retweetedBy: XUser | null; // set only when the timeline entry is a retweet
+  media: XMediaEntry[];
+  urls: XUrlEntry[];
+}
+
+export interface FetchUserTweetsOptions {
+  sinceId?: string | null;
+  maxResults?: number;
+  maxPages?: number;
+  includeRetweets?: boolean;
+  includeReplies?: boolean;
+}
+
+export interface FetchUserTweetsSuccess {
+  ok: true;
+  tweets: XTweet[];
+}
+
+export interface FetchUserTweetsFailure {
+  ok: false;
+  error: XError;
+}
+
+export type FetchUserTweetsResult = FetchUserTweetsSuccess | FetchUserTweetsFailure;
+
+export interface LookupUsersSuccess {
+  ok: true;
+  result: XUserLookup;
+}
+
+export interface LookupUsersFailure {
+  ok: false;
+  error: XError;
+}
+
+export type LookupUsersResult = LookupUsersSuccess | LookupUsersFailure;
+
+interface RawUser {
+  id: string;
+  username: string;
+  name: string;
+  profile_image_url?: string;
+}
+
+interface RawMedia {
+  media_key: string;
+  type: string;
+  url?: string;
+  preview_image_url?: string;
+}
+
+interface RawUrlEntity {
+  url: string;
+  expanded_url?: string;
+  display_url?: string;
+}
+
+interface RawReferencedTweet {
+  type: string; // "retweeted" | "quoted" | "replied_to"
+  id: string;
+}
+
+interface RawTweet {
+  id: string;
+  text: string;
+  created_at: string;
+  author_id: string;
+  lang?: string;
+  attachments?: { media_keys?: string[] };
+  entities?: { urls?: RawUrlEntity[] };
+  referenced_tweets?: RawReferencedTweet[];
+}
+
+interface RawTweetsResponse {
+  data?: RawTweet[];
+  includes?: {
+    media?: RawMedia[];
+    tweets?: RawTweet[];
+    users?: RawUser[];
+  };
+  meta?: {
+    result_count?: number;
+    next_token?: string;
+    newest_id?: string;
+    oldest_id?: string;
+  };
+  errors?: unknown;
+}
+
+interface RawUsersResponse {
+  data?: RawUser[];
+  errors?: Array<{ parameter?: string; value?: string; detail?: string }>;
+}
+
+export function normalizeProfileImageUrl(url: string | undefined | null): string | null {
+  if (!url) {
+    return null;
+  }
+  return url.replace(/_normal(\.(?:jpg|jpeg|png|gif|webp))/i, "_400x400$1");
+}
+
+export function parseRateLimitHeaders(headers: Headers): { resetAt?: string } {
+  const reset = headers.get("x-rate-limit-reset");
+  if (!reset) {
+    return {};
+  }
+  const seconds = Number(reset);
+  if (!Number.isFinite(seconds)) {
+    return {};
+  }
+  return { resetAt: new Date(seconds * 1000).toISOString() };
+}
+
+function classifyHttpError(status: number, headers: Headers, fallbackMessage: string): XError {
+  if (status === 401 || status === 403) {
+    return { code: "unauthorized", message: `X API returned ${status}: ${fallbackMessage}` };
+  }
+  if (status === 404) {
+    return { code: "account_not_found", message: `X API returned 404: ${fallbackMessage}` };
+  }
+  if (status === 429) {
+    const { resetAt } = parseRateLimitHeaders(headers);
+    return {
+      code: "rate_limited",
+      message: `X API returned 429: ${fallbackMessage}`,
+      ...(resetAt ? { resetAt } : {}),
+    };
+  }
+  return { code: "fetch_failed", message: `X API returned ${status}: ${fallbackMessage}` };
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return "<no body>";
+  }
+}
+
+function resolveXUser(userId: string, usersMap: ReadonlyMap<string, XUser>): XUser {
+  const found = usersMap.get(userId);
+  if (found) {
+    return found;
+  }
+  // Fallback when the API did not include a user record for this id — should
+  // not normally happen because we request author_id expansion, but callers
+  // still need a sensible author object rather than a crash.
+  return { id: userId, username: `id_${userId}`, name: "", profileImageUrl: null };
+}
+
+function mapRawMedia(mediaKeys: readonly string[] | undefined, mediaMap: ReadonlyMap<string, RawMedia>): XMediaEntry[] {
+  return (mediaKeys ?? [])
+    .map((key): XMediaEntry | null => {
+      const media = mediaMap.get(key);
+      if (!media) return null;
+      return {
+        type: media.type,
+        url: media.url ?? null,
+        previewImageUrl: media.preview_image_url ?? null,
+        mediaKey: media.media_key,
+      };
+    })
+    .filter((m): m is XMediaEntry => m !== null);
+}
+
+function mapRawUrls(entities: RawTweet["entities"]): XUrlEntry[] {
+  return (entities?.urls ?? [])
+    .map((entry): XUrlEntry | null => {
+      if (!entry.expanded_url) return null;
+      return {
+        url: entry.url,
+        expandedUrl: entry.expanded_url,
+        displayUrl: entry.display_url ?? entry.expanded_url,
+      };
+    })
+    .filter((u): u is XUrlEntry => u !== null);
+}
+
+/**
+ * Converts a single raw timeline entry into the internal {@link XTweet}
+ * shape, resolving retweet indirection so callers always see the original
+ * author and full content. Exported for test setup; not intended as a
+ * general-purpose public helper.
+ *
+ * Quote tweets (`type === "quoted"`) and replies (`type === "replied_to"`)
+ * intentionally pass through unchanged: the quoter/replier is the
+ * effective author because the visible content is their own commentary,
+ * not the referenced tweet.
+ */
+export function buildXTweetFromRaw(
+  raw: RawTweet,
+  usersMap: ReadonlyMap<string, XUser>,
+  includedTweetsMap: ReadonlyMap<string, RawTweet>,
+  mediaMap: ReadonlyMap<string, RawMedia>,
+): XTweet {
+  const retweetRef = raw.referenced_tweets?.find((r) => r.type === "retweeted");
+  const original = retweetRef ? includedTweetsMap.get(retweetRef.id) : undefined;
+  const isRetweet = original !== undefined;
+
+  // For retweets the visible content (text/media/urls/author) comes from
+  // the referenced original tweet, while the timeline entry (id,
+  // created_at) stays the outer one so since_id tracking still works and
+  // the retweet event appears at its actual time in chronological sort.
+  const contentSource = original ?? raw;
+
+  const author = resolveXUser(contentSource.author_id, usersMap);
+  const retweetedBy =
+    isRetweet && raw.author_id !== contentSource.author_id ? resolveXUser(raw.author_id, usersMap) : null;
+
+  return {
+    id: raw.id,
+    sourceTweetId: contentSource.id,
+    text: contentSource.text,
+    createdAt: raw.created_at,
+    lang: contentSource.lang ?? null,
+    author,
+    retweetedBy,
+    media: mapRawMedia(contentSource.attachments?.media_keys, mediaMap),
+    urls: mapRawUrls(contentSource.entities),
+  };
+}
+
+export class XClient {
+  constructor(private readonly bearerToken: string) {}
+
+  async lookupUsers(usernames: readonly string[]): Promise<LookupUsersResult> {
+    const unique = Array.from(new Set(usernames.map((u) => u.toLowerCase()))).filter((u) => u.length > 0);
+    if (unique.length === 0) {
+      return { ok: true, result: { found: new Map(), missing: [] } };
+    }
+
+    const found = new Map<string, XUser>();
+    const missing = new Set<string>(unique);
+
+    for (let i = 0; i < unique.length; i += USER_LOOKUP_BATCH_SIZE) {
+      const batch = unique.slice(i, i + USER_LOOKUP_BATCH_SIZE);
+      const url = new URL(`${X_API_BASE}/users/by`);
+      url.searchParams.set("usernames", batch.join(","));
+      url.searchParams.set("user.fields", "id,username,name,profile_image_url");
+
+      let response: Response;
+      try {
+        response = await fetch(url, { headers: this.buildHeaders() });
+      } catch (error) {
+        return {
+          ok: false,
+          error: { code: "fetch_failed", message: `network error: ${(error as Error).message}` },
+        };
+      }
+
+      if (!response.ok) {
+        const text = await safeReadText(response);
+        return { ok: false, error: classifyHttpError(response.status, response.headers, text) };
+      }
+
+      let body: RawUsersResponse;
+      try {
+        body = (await response.json()) as RawUsersResponse;
+      } catch (error) {
+        return {
+          ok: false,
+          error: { code: "fetch_failed", message: `invalid JSON from /users/by: ${(error as Error).message}` },
+        };
+      }
+
+      for (const user of body.data ?? []) {
+        const key = user.username.toLowerCase();
+        found.set(key, {
+          id: user.id,
+          username: user.username,
+          name: user.name,
+          profileImageUrl: normalizeProfileImageUrl(user.profile_image_url),
+        });
+        missing.delete(key);
+      }
+    }
+
+    return { ok: true, result: { found, missing: Array.from(missing) } };
+  }
+
+  async fetchUserTweets(userId: string, options: FetchUserTweetsOptions = {}): Promise<FetchUserTweetsResult> {
+    const {
+      sinceId,
+      maxResults = DEFAULT_PAGE_SIZE,
+      maxPages = DEFAULT_MAX_PAGES,
+      includeRetweets = false,
+      includeReplies = false,
+    } = options;
+
+    const tweets: XTweet[] = [];
+    let nextToken: string | undefined;
+    let page = 0;
+
+    while (page < maxPages) {
+      const url = new URL(`${X_API_BASE}/users/${encodeURIComponent(userId)}/tweets`);
+      url.searchParams.set("max_results", String(maxResults));
+      url.searchParams.set("tweet.fields", "id,text,created_at,author_id,lang,attachments,entities,referenced_tweets");
+      url.searchParams.set(
+        "expansions",
+        "author_id,attachments.media_keys,referenced_tweets.id,referenced_tweets.id.author_id",
+      );
+      url.searchParams.set("media.fields", "url,preview_image_url,type");
+      url.searchParams.set("user.fields", "id,username,name,profile_image_url");
+      const excludes: string[] = [];
+      if (!includeRetweets) excludes.push("retweets");
+      if (!includeReplies) excludes.push("replies");
+      if (excludes.length > 0) {
+        url.searchParams.set("exclude", excludes.join(","));
+      }
+      if (sinceId) {
+        url.searchParams.set("since_id", sinceId);
+      }
+      if (nextToken) {
+        url.searchParams.set("pagination_token", nextToken);
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(url, { headers: this.buildHeaders() });
+      } catch (error) {
+        return {
+          ok: false,
+          error: { code: "fetch_failed", message: `network error: ${(error as Error).message}` },
+        };
+      }
+
+      if (!response.ok) {
+        const text = await safeReadText(response);
+        return { ok: false, error: classifyHttpError(response.status, response.headers, text) };
+      }
+
+      let body: RawTweetsResponse;
+      try {
+        body = (await response.json()) as RawTweetsResponse;
+      } catch (error) {
+        return {
+          ok: false,
+          error: {
+            code: "fetch_failed",
+            message: `invalid JSON from /users/:id/tweets: ${(error as Error).message}`,
+          },
+        };
+      }
+
+      const mediaMap = new Map<string, RawMedia>();
+      for (const media of body.includes?.media ?? []) {
+        mediaMap.set(media.media_key, media);
+      }
+
+      const usersMap = new Map<string, XUser>();
+      for (const rawUser of body.includes?.users ?? []) {
+        usersMap.set(rawUser.id, {
+          id: rawUser.id,
+          username: rawUser.username,
+          name: rawUser.name,
+          profileImageUrl: normalizeProfileImageUrl(rawUser.profile_image_url),
+        });
+      }
+
+      const includedTweetsMap = new Map<string, RawTweet>();
+      for (const includedTweet of body.includes?.tweets ?? []) {
+        includedTweetsMap.set(includedTweet.id, includedTweet);
+      }
+
+      for (const raw of body.data ?? []) {
+        const tweet = buildXTweetFromRaw(raw, usersMap, includedTweetsMap, mediaMap);
+        if (tweet) {
+          tweets.push(tweet);
+        }
+      }
+
+      page += 1;
+      nextToken = body.meta?.next_token;
+      if (!nextToken) {
+        break;
+      }
+    }
+
+    return { ok: true, tweets };
+  }
+
+  private buildHeaders(): HeadersInit {
+    return {
+      Authorization: `Bearer ${this.bearerToken}`,
+      Accept: "application/json",
+    };
+  }
+}
+
+/**
+ * Public shape of {@link XClient}, usable as a dependency-injection type for
+ * tests or wrappers that only need the two HTTP methods without the private
+ * bearer-token state.
+ */
+export type XClientApi = Pick<XClient, "lookupUsers" | "fetchUserTweets">;

--- a/test/twcheck/main.test.ts
+++ b/test/twcheck/main.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import type { PostEntry, RunOptions } from "@/twcheck/main.js";
+import { buildPostEntry, buildRunOutput, parseArgs, processAccount, sortPostsChronologically } from "@/twcheck/main.js";
+import { emptyState, STATE_VERSION } from "@/twcheck/state.js";
+import type { FetchUserTweetsOptions, XClientApi, XTweet, XUser } from "@/twcheck/xClient.js";
+
+// ── parseArgs ────────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  const makeArgv = (...rest: string[]) => ["node", "cli.js", ...rest];
+
+  it("returns defaults when only positional usernames are given", () => {
+    const options = parseArgs(makeArgv("elonmusk", "sama"));
+    expect(options).toEqual({
+      usernames: ["elonmusk", "sama"],
+      statePath: "./twcheck_state.json",
+      includeRetweets: false,
+      includeReplies: false,
+    });
+  });
+
+  it("parses flags", () => {
+    const options = parseArgs(makeArgv("--state", "/tmp/s.json", "--include-retweets", "--include-replies", "elon"));
+    expect(options).toEqual({
+      usernames: ["elon"],
+      statePath: "/tmp/s.json",
+      includeRetweets: true,
+      includeReplies: true,
+    });
+  });
+
+  it("strips a leading @ from usernames", () => {
+    const options = parseArgs(makeArgv("@elonmusk"));
+    expect(options.usernames).toEqual(["elonmusk"]);
+  });
+});
+
+// ── buildPostEntry & sorting ─────────────────────────────────
+
+const sampleUser: XUser = {
+  id: "123",
+  username: "elonmusk",
+  name: "Elon",
+  profileImageUrl: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
+};
+
+const makeTweet = (id: string, createdAt: string, extra: Partial<XTweet> = {}): XTweet => ({
+  id,
+  sourceTweetId: id,
+  text: `tweet ${id}`,
+  createdAt,
+  lang: "en",
+  author: sampleUser,
+  retweetedBy: null,
+  media: [],
+  urls: [],
+  ...extra,
+});
+
+describe("buildPostEntry", () => {
+  it("builds the post url from the tweet author username and sourceTweetId", () => {
+    const entry = buildPostEntry(makeTweet("9001", "2026-04-11T12:00:00.000Z"));
+    expect(entry.url).toBe("https://x.com/elonmusk/status/9001");
+  });
+
+  it("embeds author and media", () => {
+    const tweet = makeTweet("5", "2026-04-11T12:00:00.000Z", {
+      media: [{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", previewImageUrl: null, mediaKey: "k1" }],
+    });
+    const entry = buildPostEntry(tweet);
+    expect(entry.author).toEqual({
+      id: "123",
+      username: "elonmusk",
+      name: "Elon",
+      profile_image_url: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
+    });
+    expect(entry.media).toEqual([{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", preview_image_url: null }]);
+  });
+
+  it("defaults retweeted_by to null for normal tweets", () => {
+    const entry = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"));
+    expect(entry.retweeted_by).toBeNull();
+  });
+
+  it("maps tweet entities.urls to post urls with snake_case keys", () => {
+    const tweet = makeTweet("5", "2026-04-11T12:00:00.000Z", {
+      urls: [
+        {
+          url: "https://t.co/abc",
+          expandedUrl: "https://example.com/page",
+          displayUrl: "example.com/page",
+        },
+      ],
+    });
+    const entry = buildPostEntry(tweet);
+    expect(entry.urls).toEqual([
+      { url: "https://t.co/abc", expanded_url: "https://example.com/page", display_url: "example.com/page" },
+    ]);
+  });
+
+  it("returns an empty urls array when the tweet has no link entities", () => {
+    const entry = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"));
+    expect(entry.urls).toEqual([]);
+  });
+
+  it("surfaces the original author in author and the retweeter in retweeted_by for retweets", () => {
+    const originalAuthor: XUser = {
+      id: "999",
+      username: "sama",
+      name: "Sam",
+      profileImageUrl: "https://pbs.twimg.com/profile_images/2/s_400x400.jpg",
+    };
+    const tweet: XTweet = {
+      id: "1700", // retweet entry id on elonmusk's timeline
+      sourceTweetId: "1500", // original tweet id by sama
+      text: "full original text",
+      createdAt: "2026-04-11T12:00:00.000Z",
+      lang: "en",
+      author: originalAuthor,
+      retweetedBy: sampleUser,
+      media: [],
+      urls: [],
+    };
+    const entry = buildPostEntry(tweet);
+    expect(entry.id).toBe("1700");
+    expect(entry.url).toBe("https://x.com/sama/status/1500");
+    expect(entry.text).toBe("full original text");
+    expect(entry.author).toEqual({
+      id: "999",
+      username: "sama",
+      name: "Sam",
+      profile_image_url: "https://pbs.twimg.com/profile_images/2/s_400x400.jpg",
+    });
+    expect(entry.retweeted_by).toEqual({
+      id: "123",
+      username: "elonmusk",
+      name: "Elon",
+      profile_image_url: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
+    });
+  });
+});
+
+describe("sortPostsChronologically", () => {
+  it("sorts posts from multiple authors in ascending created_at order", () => {
+    const a = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"), sampleUser);
+    const b = buildPostEntry(makeTweet("2", "2026-04-11T11:00:00.000Z"), sampleUser);
+    const c = buildPostEntry(makeTweet("3", "2026-04-11T13:00:00.000Z"), sampleUser);
+    const sorted = sortPostsChronologically([a, b, c]);
+    expect(sorted.map((p) => p.id)).toEqual(["2", "1", "3"]);
+  });
+});
+
+// ── buildRunOutput ───────────────────────────────────────────
+
+describe("buildRunOutput", () => {
+  const NOW = new Date("2026-04-11T12:34:56.000Z");
+
+  it("builds the full output shape with summary counts", () => {
+    const posts: PostEntry[] = [
+      buildPostEntry(makeTweet("100", "2026-04-11T11:00:00.000Z"), sampleUser),
+      buildPostEntry(makeTweet("101", "2026-04-11T12:00:00.000Z"), sampleUser),
+    ];
+    const output = buildRunOutput(NOW, 3, 1, posts, [
+      { username: "ghost", code: "account_not_found", message: "not found" },
+    ]);
+    expect(output.checked_at).toBe("2026-04-11T12:34:56.000Z");
+    expect(output.posts.map((p) => p.id)).toEqual(["100", "101"]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.summary).toEqual({
+      total_accounts: 3,
+      baseline_established: 1,
+      total_posts: 2,
+      errors: 1,
+    });
+  });
+});
+
+// ── processAccount ───────────────────────────────────────────
+
+function makeClient(fetchImpl: (userId: string, opts?: FetchUserTweetsOptions) => Promise<XTweet[]>): XClientApi {
+  return {
+    lookupUsers: async () => ({ ok: true, result: { found: new Map(), missing: [] } }),
+    fetchUserTweets: async (userId, opts) => {
+      const tweets = await fetchImpl(userId, opts);
+      return { ok: true as const, tweets };
+    },
+  };
+}
+
+const baseOptions: Pick<RunOptions, "includeRetweets" | "includeReplies"> = {
+  includeRetweets: false,
+  includeReplies: false,
+};
+
+describe("processAccount", () => {
+  it("returns baseline_established on first run without producing posts", async () => {
+    let capturedOpts: FetchUserTweetsOptions | undefined;
+    const client = makeClient(async (_id, opts) => {
+      capturedOpts = opts;
+      return [makeTweet("999", "2026-04-11T12:00:00.000Z")];
+    });
+    const state = emptyState();
+    const processed = await processAccount("elonmusk", sampleUser, state, client, baseOptions);
+    expect(processed.accountResult.status).toBe("baseline_established");
+    expect(processed.accountResult.newLastSeenId).toBe("999");
+    expect(processed.posts).toEqual([]);
+    expect(processed.baselineEstablished).toBe(true);
+    // On baseline run, sinceId must not be set and max_results is small.
+    expect(capturedOpts?.sinceId).toBeUndefined();
+    expect(capturedOpts?.maxResults).toBe(5);
+    expect(capturedOpts?.maxPages).toBe(1);
+  });
+
+  it("uses the cached lastSeenId as since_id on subsequent runs", async () => {
+    let capturedOpts: FetchUserTweetsOptions | undefined;
+    const client = makeClient(async (_id, opts) => {
+      capturedOpts = opts;
+      return [makeTweet("200", "2026-04-11T12:00:00.000Z"), makeTweet("199", "2026-04-11T11:00:00.000Z")];
+    });
+    const state = {
+      version: STATE_VERSION as 1,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
+      },
+    };
+    const processed = await processAccount("elonmusk", sampleUser, state, client, baseOptions);
+    expect(capturedOpts?.sinceId).toBe("100");
+    // Subsequent runs should use the xClient defaults (page size / max pages).
+    expect(capturedOpts?.maxResults).toBeUndefined();
+    expect(capturedOpts?.maxPages).toBeUndefined();
+    expect(processed.accountResult).toEqual({
+      username: "elonmusk",
+      status: "ok",
+      newLastSeenId: "200",
+    });
+    expect(processed.posts.map((p) => p.id)).toEqual(["200", "199"]);
+  });
+
+  it("preserves cached lastSeenId on a subsequent run with no new tweets", async () => {
+    const client = makeClient(async () => []);
+    const state = {
+      version: STATE_VERSION as 1,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
+      },
+    };
+    const processed = await processAccount("elonmusk", sampleUser, state, client, baseOptions);
+    expect(processed.accountResult).toEqual({
+      username: "elonmusk",
+      status: "ok",
+      newLastSeenId: "100",
+    });
+    expect(processed.posts).toEqual([]);
+    expect(processed.errorEntry).toBeNull();
+    expect(processed.baselineEstablished).toBe(false);
+  });
+
+  it("returns an error entry when fetchUserTweets fails", async () => {
+    const client: XClientApi = {
+      lookupUsers: async () => ({ ok: true, result: { found: new Map(), missing: [] } }),
+      fetchUserTweets: async () => ({
+        ok: false,
+        error: { code: "rate_limited", message: "429", resetAt: "2026-04-11T13:00:00.000Z" },
+      }),
+    };
+    const state = {
+      version: STATE_VERSION as 1,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
+      },
+    };
+    const processed = await processAccount("elonmusk", sampleUser, state, client, baseOptions);
+    expect(processed.accountResult.status).toBe("error");
+    expect(processed.errorEntry).toEqual({
+      username: "elonmusk",
+      code: "rate_limited",
+      message: "429",
+      reset_at: "2026-04-11T13:00:00.000Z",
+    });
+    expect(processed.posts).toEqual([]);
+  });
+
+  it("returns empty baseline when account has zero tweets", async () => {
+    const client = makeClient(async () => []);
+    const processed = await processAccount("elonmusk", sampleUser, emptyState(), client, baseOptions);
+    expect(processed.accountResult).toEqual({
+      username: "elonmusk",
+      status: "baseline_established",
+      newLastSeenId: null,
+    });
+  });
+});

--- a/test/twcheck/state.test.ts
+++ b/test/twcheck/state.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AccountRunResult, TwcheckState } from "@/twcheck/state.js";
+import {
+  emptyState,
+  getAccountState,
+  loadState,
+  mergeStateAfterRun,
+  resolveStatePath,
+  STATE_VERSION,
+  saveState,
+} from "@/twcheck/state.js";
+
+describe("resolveStatePath", () => {
+  it("leaves absolute paths alone", () => {
+    expect(resolveStatePath("/tmp/custom.json")).toBe("/tmp/custom.json");
+  });
+
+  it("resolves relative paths against cwd", () => {
+    const resolved = resolveStatePath("./twcheck_state.json");
+    expect(resolved.startsWith("/")).toBe(true);
+    expect(resolved.endsWith("twcheck_state.json")).toBe(true);
+  });
+});
+
+describe("loadState", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "twcheck-state-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty state when file is missing", async () => {
+    const state = await loadState(join(dir, "missing.json"));
+    expect(state).toEqual(emptyState());
+  });
+
+  it("loads a valid state file", async () => {
+    const path = join(dir, "state.json");
+    const initial: TwcheckState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "12345", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    await writeFile(path, JSON.stringify(initial), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(initial);
+  });
+
+  it("falls back to empty state on JSON parse error", async () => {
+    const path = join(dir, "broken.json");
+    await writeFile(path, "not json at all", "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+
+  it("falls back to empty state on version mismatch", async () => {
+    const path = join(dir, "oldversion.json");
+    await writeFile(path, JSON.stringify({ version: 0, accounts: {} }), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+
+  it("falls back to empty state when accounts entry schema is wrong", async () => {
+    const path = join(dir, "badschema.json");
+    await writeFile(path, JSON.stringify({ version: STATE_VERSION, accounts: { a: 42 } }), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+});
+
+describe("saveState", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "twcheck-save-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes state atomically and is round-trippable", async () => {
+    const path = join(dir, "nested/a/b/state.json");
+    const state: TwcheckState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "999", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
+      },
+    };
+    await saveState(state, path);
+    const raw = await readFile(path, "utf8");
+    expect(JSON.parse(raw)).toEqual(state);
+
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(state);
+  });
+});
+
+describe("mergeStateAfterRun", () => {
+  const NOW = new Date("2026-04-11T12:00:00.000Z");
+
+  it("updates lastSeenId for successful accounts", () => {
+    const state: TwcheckState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    const results: AccountRunResult[] = [{ username: "elonmusk", status: "ok", newLastSeenId: "200" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "200",
+      lastCheckedAt: NOW.toISOString(),
+    });
+  });
+
+  it("keeps existing lastSeenId when error occurs", () => {
+    const state: TwcheckState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    const results: AccountRunResult[] = [{ username: "elonmusk", status: "error" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "100",
+      lastCheckedAt: "2026-04-01T00:00:00.000Z",
+    });
+  });
+
+  it("records baseline_established entries with their newLastSeenId", () => {
+    const state = emptyState();
+    const results: AccountRunResult[] = [
+      { username: "elonmusk", status: "baseline_established", newLastSeenId: "555" },
+    ];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "555",
+      lastCheckedAt: NOW.toISOString(),
+    });
+  });
+
+  it("stores account keys case-insensitively", () => {
+    const state = emptyState();
+    const results: AccountRunResult[] = [{ username: "ElonMusk", status: "ok", newLastSeenId: "1" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toBeDefined();
+    expect(next.accounts.ElonMusk).toBeUndefined();
+  });
+});
+
+describe("getAccountState", () => {
+  it("looks up accounts case-insensitively", () => {
+    const state: TwcheckState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "1", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    expect(getAccountState(state, "ElonMusk")?.lastSeenId).toBe("1");
+    expect(getAccountState(state, "sama")).toBeUndefined();
+  });
+});

--- a/test/twcheck/xClient.test.ts
+++ b/test/twcheck/xClient.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeProfileImageUrl, parseRateLimitHeaders, XClient } from "@/twcheck/xClient.js";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function errorResponse(status: number, body = "error body", headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain", ...headers },
+  });
+}
+
+describe("normalizeProfileImageUrl", () => {
+  it("replaces _normal suffix with _400x400", () => {
+    const input = "https://pbs.twimg.com/profile_images/1/avatar_normal.jpg";
+    expect(normalizeProfileImageUrl(input)).toBe("https://pbs.twimg.com/profile_images/1/avatar_400x400.jpg");
+  });
+
+  it("handles png extension", () => {
+    expect(normalizeProfileImageUrl("https://example/a_normal.png")).toBe("https://example/a_400x400.png");
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(normalizeProfileImageUrl(null)).toBeNull();
+    expect(normalizeProfileImageUrl(undefined)).toBeNull();
+    expect(normalizeProfileImageUrl("")).toBeNull();
+  });
+
+  it("leaves URLs without _normal unchanged", () => {
+    const url = "https://pbs.twimg.com/profile_images/1/avatar_400x400.jpg";
+    expect(normalizeProfileImageUrl(url)).toBe(url);
+  });
+});
+
+describe("parseRateLimitHeaders", () => {
+  it("parses x-rate-limit-reset as unix seconds", () => {
+    const headers = new Headers({ "x-rate-limit-reset": "1712000000" });
+    expect(parseRateLimitHeaders(headers)).toEqual({ resetAt: new Date(1712000000 * 1000).toISOString() });
+  });
+
+  it("returns empty object when header missing", () => {
+    expect(parseRateLimitHeaders(new Headers())).toEqual({});
+  });
+
+  it("returns empty object when header is not numeric", () => {
+    const headers = new Headers({ "x-rate-limit-reset": "oops" });
+    expect(parseRateLimitHeaders(headers)).toEqual({});
+  });
+});
+
+describe("XClient.lookupUsers", () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls /users/by with user.fields including profile_image_url", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "1",
+            username: "elonmusk",
+            name: "Elon",
+            profile_image_url: "https://pbs.twimg.com/profile_images/1/e_normal.jpg",
+          },
+        ],
+      }),
+    );
+    const client = new XClient("token");
+    const result = await client.lookupUsers(["ElonMusk"]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    const user = result.result.found.get("elonmusk");
+    expect(user).toEqual({
+      id: "1",
+      username: "elonmusk",
+      name: "Elon",
+      profileImageUrl: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
+    });
+    expect(result.result.missing).toEqual([]);
+
+    const calledUrl = fetchMock.mock.calls[0][0] as URL;
+    expect(calledUrl.searchParams.get("usernames")).toBe("elonmusk");
+    expect(calledUrl.searchParams.get("user.fields")).toContain("profile_image_url");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer token");
+  });
+
+  it("reports missing usernames from the server response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ id: "1", username: "exists", name: "Exists", profile_image_url: "https://a/b_normal.jpg" }],
+      }),
+    );
+    const client = new XClient("token");
+    const result = await client.lookupUsers(["exists", "ghost"]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.result.missing).toEqual(["ghost"]);
+  });
+
+  it("batches usernames into chunks of 100", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse({ data: [] })));
+    const usernames = Array.from({ length: 150 }, (_, i) => `user${i}`);
+    const client = new XClient("token");
+    await client.lookupUsers(usernames);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstUrl = fetchMock.mock.calls[0][0] as URL;
+    const secondUrl = fetchMock.mock.calls[1][0] as URL;
+    expect(firstUrl.searchParams.get("usernames")?.split(",").length).toBe(100);
+    expect(secondUrl.searchParams.get("usernames")?.split(",").length).toBe(50);
+  });
+
+  it("returns unauthorized on 401", async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(401, "unauthorized"));
+    const client = new XClient("token");
+    const result = await client.lookupUsers(["elonmusk"]);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected ok");
+    expect(result.error.code).toBe("unauthorized");
+  });
+
+  it("returns empty result for empty input without calling fetch", async () => {
+    const client = new XClient("token");
+    const result = await client.lookupUsers([]);
+    expect(result.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("XClient.fetchUserTweets", () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("passes since_id, max_results and default excludes", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [], meta: { result_count: 0 } }));
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("123", { sinceId: "999" });
+    expect(result.ok).toBe(true);
+
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.pathname).toBe("/2/users/123/tweets");
+    expect(url.searchParams.get("since_id")).toBe("999");
+    expect(url.searchParams.get("max_results")).toBe("100");
+    expect(url.searchParams.get("exclude")).toBe("retweets,replies");
+    const expansions = url.searchParams.get("expansions") ?? "";
+    expect(expansions).toContain("author_id");
+    expect(expansions).toContain("attachments.media_keys");
+    expect(expansions).toContain("referenced_tweets.id");
+    expect(expansions).toContain("referenced_tweets.id.author_id");
+    const tweetFields = url.searchParams.get("tweet.fields") ?? "";
+    expect(tweetFields).toContain("entities");
+    expect(tweetFields).toContain("referenced_tweets");
+    expect(url.searchParams.get("user.fields")).toContain("profile_image_url");
+  });
+
+  it("omits exclude when both include flags are set", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: [], meta: { result_count: 0 } }));
+    const client = new XClient("token");
+    await client.fetchUserTweets("123", { includeRetweets: true, includeReplies: true });
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.searchParams.get("exclude")).toBeNull();
+  });
+
+  it("maps media entries via media_key expansion", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "100",
+            text: "hi",
+            created_at: "2026-04-11T00:00:00.000Z",
+            author_id: "1",
+            lang: "en",
+            attachments: { media_keys: ["m1"] },
+          },
+        ],
+        includes: {
+          media: [{ media_key: "m1", type: "photo", url: "https://pbs.twimg.com/media/m1.jpg" }],
+          users: [{ id: "1", username: "elonmusk", name: "Elon", profile_image_url: "https://pbs/e_normal.jpg" }],
+        },
+        meta: { result_count: 1 },
+      }),
+    );
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0].media).toEqual([
+      {
+        type: "photo",
+        url: "https://pbs.twimg.com/media/m1.jpg",
+        previewImageUrl: null,
+        mediaKey: "m1",
+      },
+    ]);
+    expect(result.tweets[0].lang).toBe("en");
+    expect(result.tweets[0].author.username).toBe("elonmusk");
+    expect(result.tweets[0].retweetedBy).toBeNull();
+    expect(result.tweets[0].sourceTweetId).toBe("100");
+  });
+
+  it("maps entities.urls to XTweet.urls", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "100",
+            text: "check this out https://t.co/abc",
+            created_at: "2026-04-11T00:00:00.000Z",
+            author_id: "1",
+            entities: {
+              urls: [
+                {
+                  url: "https://t.co/abc",
+                  expanded_url: "https://example.com/page",
+                  display_url: "example.com/page",
+                },
+                {
+                  url: "https://t.co/no-expand",
+                },
+              ],
+            },
+          },
+        ],
+        meta: { result_count: 1 },
+      }),
+    );
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.tweets[0].urls).toEqual([
+      {
+        url: "https://t.co/abc",
+        expandedUrl: "https://example.com/page",
+        displayUrl: "example.com/page",
+      },
+    ]);
+  });
+
+  it("returns an empty urls array when the tweet has no entities field", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "100",
+            text: "no links",
+            created_at: "2026-04-11T00:00:00.000Z",
+            author_id: "1",
+          },
+        ],
+        meta: { result_count: 1 },
+      }),
+    );
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.tweets[0].urls).toEqual([]);
+  });
+
+  it("resolves retweets from includes and swaps the author with the original poster", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "1700",
+            text: "RT @sama: this will be truncat…",
+            created_at: "2026-04-11T12:00:00.000Z",
+            author_id: "elon_id",
+            referenced_tweets: [{ type: "retweeted", id: "1500" }],
+          },
+        ],
+        includes: {
+          users: [
+            { id: "elon_id", username: "elonmusk", name: "Elon", profile_image_url: "https://pbs/e_normal.jpg" },
+            { id: "sama_id", username: "sama", name: "Sam", profile_image_url: "https://pbs/s_normal.jpg" },
+          ],
+          tweets: [
+            {
+              id: "1500",
+              text: "full original text from sama",
+              created_at: "2026-04-10T09:00:00.000Z",
+              author_id: "sama_id",
+              lang: "en",
+              entities: {
+                urls: [
+                  {
+                    url: "https://t.co/link",
+                    expanded_url: "https://example.com/page",
+                    display_url: "example.com/page",
+                  },
+                ],
+              },
+              attachments: { media_keys: ["m9"] },
+            },
+          ],
+          media: [{ media_key: "m9", type: "photo", url: "https://pbs.twimg.com/media/m9.jpg" }],
+        },
+        meta: { result_count: 1 },
+      }),
+    );
+
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("elon_id", { includeRetweets: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.tweets).toHaveLength(1);
+    const tweet = result.tweets[0];
+    expect(tweet.id).toBe("1700"); // retweet entry id stays as the output id for since_id tracking
+    expect(tweet.sourceTweetId).toBe("1500"); // original id for URL generation
+    expect(tweet.text).toBe("full original text from sama");
+    expect(tweet.createdAt).toBe("2026-04-11T12:00:00.000Z"); // retweet time, not original
+    expect(tweet.lang).toBe("en");
+    expect(tweet.author.username).toBe("sama");
+    expect(tweet.retweetedBy?.username).toBe("elonmusk");
+    expect(tweet.media.map((m) => m.mediaKey)).toEqual(["m9"]);
+    expect(tweet.urls.map((u) => u.expandedUrl)).toEqual(["https://example.com/page"]);
+  });
+
+  it("falls back to the retweeter as author when the referenced tweet is missing from includes", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: "1700",
+            text: "RT @sama: truncated…",
+            created_at: "2026-04-11T12:00:00.000Z",
+            author_id: "elon_id",
+            referenced_tweets: [{ type: "retweeted", id: "1500" }],
+          },
+        ],
+        includes: {
+          users: [{ id: "elon_id", username: "elonmusk", name: "Elon", profile_image_url: "https://pbs/e_normal.jpg" }],
+        },
+        meta: { result_count: 1 },
+      }),
+    );
+
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("elon_id", { includeRetweets: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    const tweet = result.tweets[0];
+    expect(tweet.author.username).toBe("elonmusk");
+    expect(tweet.retweetedBy).toBeNull();
+    expect(tweet.text).toBe("RT @sama: truncated…");
+    expect(tweet.sourceTweetId).toBe("1700");
+  });
+
+  it("follows pagination_token up to maxPages", async () => {
+    const page1Tweets = Array.from({ length: 5 }, (_, i) => ({
+      id: `${100 + i}`,
+      text: `t${i}`,
+      created_at: "2026-04-11T00:00:00.000Z",
+      author_id: "1",
+    }));
+    const page2Tweets = Array.from({ length: 3 }, (_, i) => ({
+      id: `${200 + i}`,
+      text: `t${i}`,
+      created_at: "2026-04-11T00:00:00.000Z",
+      author_id: "1",
+    }));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: page1Tweets, meta: { result_count: 5, next_token: "tok-1" } }))
+      .mockResolvedValueOnce(jsonResponse({ data: page2Tweets, meta: { result_count: 3 } }));
+
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1", { maxResults: 5, maxPages: 3 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.tweets).toHaveLength(8);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstUrl = fetchMock.mock.calls[0][0] as URL;
+    const secondUrl = fetchMock.mock.calls[1][0] as URL;
+    expect(firstUrl.searchParams.get("pagination_token")).toBeNull();
+    expect(secondUrl.searchParams.get("pagination_token")).toBe("tok-1");
+  });
+
+  it("stops paginating when maxPages is reached", async () => {
+    const makePage = () => ({
+      data: Array.from({ length: 5 }, (_, i) => ({
+        id: `${i}`,
+        text: "t",
+        created_at: "2026-04-11T00:00:00.000Z",
+        author_id: "1",
+      })),
+      meta: { result_count: 5, next_token: "more" },
+    });
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(makePage())));
+
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1", { maxResults: 5, maxPages: 2 });
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies 429 as rate_limited and extracts reset time", async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(429, "slow down", { "x-rate-limit-reset": "1712000000" }));
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected ok");
+    expect(result.error.code).toBe("rate_limited");
+    expect(result.error.resetAt).toBe(new Date(1712000000 * 1000).toISOString());
+  });
+
+  it("classifies 404 as account_not_found", async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404));
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected ok");
+    expect(result.error.code).toBe("account_not_found");
+  });
+
+  it("classifies 500 as fetch_failed", async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(500));
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected ok");
+    expect(result.error.code).toBe("fetch_failed");
+  });
+
+  it("maps network errors to fetch_failed", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const client = new XClient("token");
+    const result = await client.fetchUserTweets("1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected ok");
+    expect(result.error.code).toBe("fetch_failed");
+    expect(result.error.message).toContain("ECONNREFUSED");
+  });
+});


### PR DESCRIPTION
Poll user timelines via X API v2 and emit a flat JSON stream of posts
newer than the previous run for n8n to route into Slack. State (per-user
lastSeenId) is persisted to ./twcheck_state.json, users and profile
image URLs are fetched fresh every run, and pagination is followed so
bursts above 100 tweets are not dropped.