### PR TITLE
Change default to include retweets and add exclude flags

### DIFF
--- a/src/twcheck/main.ts
+++ b/src/twcheck/main.ts
@@ -69,7 +69,9 @@ export function parseArgs(argv: string[]): RunOptions {
     options: {
       state: { type: "string" },
       "include-retweets": { type: "boolean" },
+      "exclude-retweets": { type: "boolean" },
       "include-replies": { type: "boolean" },
+      "exclude-replies": { type: "boolean" },
     },
     allowPositionals: true,
   });
@@ -77,8 +79,8 @@ export function parseArgs(argv: string[]): RunOptions {
   return {
     usernames: positionals.map((u) => u.replace(/^@/, "")),
     statePath: values.state ?? DEFAULT_STATE_PATH,
-    includeRetweets: values["include-retweets"] ?? false,
-    includeReplies: values["include-replies"] ?? false,
+    includeRetweets: values["exclude-retweets"] ? false : (values["include-retweets"] ?? true),
+    includeReplies: values["exclude-replies"] ? false : (values["include-replies"] ?? false),
   };
 }
 

--- a/src/twcheck/xClient.ts
+++ b/src/twcheck/xClient.ts
@@ -328,7 +328,7 @@ export class XClient {
       sinceId,
       maxResults = DEFAULT_PAGE_SIZE,
       maxPages = DEFAULT_MAX_PAGES,
-      includeRetweets = false,
+      includeRetweets = true,
       includeReplies = false,
     } = options;
 

--- a/test/twcheck/main.test.ts
+++ b/test/twcheck/main.test.ts
@@ -14,12 +14,12 @@ describe("parseArgs", () => {
     expect(options).toEqual({
       usernames: ["elonmusk", "sama"],
       statePath: "./twcheck_state.json",
-      includeRetweets: false,
+      includeRetweets: true,
       includeReplies: false,
     });
   });
 
-  it("parses flags", () => {
+  it("parses --include-retweets and --include-replies flags", () => {
     const options = parseArgs(makeArgv("--state", "/tmp/s.json", "--include-retweets", "--include-replies", "elon"));
     expect(options).toEqual({
       usernames: ["elon"],
@@ -27,6 +27,23 @@ describe("parseArgs", () => {
       includeRetweets: true,
       includeReplies: true,
     });
+  });
+
+  it("parses --exclude-retweets and --exclude-replies flags", () => {
+    const options = parseArgs(makeArgv("--exclude-retweets", "--exclude-replies", "elon"));
+    expect(options).toEqual({
+      usernames: ["elon"],
+      statePath: "./twcheck_state.json",
+      includeRetweets: false,
+      includeReplies: false,
+    });
+  });
+
+  it("exclude-* takes precedence over include-* when both are set", () => {
+    const rt = parseArgs(makeArgv("--include-retweets", "--exclude-retweets", "elon"));
+    expect(rt.includeRetweets).toBe(false);
+    const rep = parseArgs(makeArgv("--include-replies", "--exclude-replies", "elon"));
+    expect(rep.includeReplies).toBe(false);
   });
 
   it("strips a leading @ from usernames", () => {
@@ -188,7 +205,7 @@ function makeClient(fetchImpl: (userId: string, opts?: FetchUserTweetsOptions) =
 }
 
 const baseOptions: Pick<RunOptions, "includeRetweets" | "includeReplies"> = {
-  includeRetweets: false,
+  includeRetweets: true,
   includeReplies: false,
 };
 

--- a/test/twcheck/xClient.test.ts
+++ b/test/twcheck/xClient.test.ts
@@ -155,7 +155,7 @@ describe("XClient.fetchUserTweets", () => {
     vi.unstubAllGlobals();
   });
 
-  it("passes since_id, max_results and default excludes", async () => {
+  it("passes since_id, max_results and default excludes (replies only by default)", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ data: [], meta: { result_count: 0 } }));
     const client = new XClient("token");
     const result = await client.fetchUserTweets("123", { sinceId: "999" });
@@ -165,7 +165,7 @@ describe("XClient.fetchUserTweets", () => {
     expect(url.pathname).toBe("/2/users/123/tweets");
     expect(url.searchParams.get("since_id")).toBe("999");
     expect(url.searchParams.get("max_results")).toBe("100");
-    expect(url.searchParams.get("exclude")).toBe("retweets,replies");
+    expect(url.searchParams.get("exclude")).toBe("replies");
     const expansions = url.searchParams.get("expansions") ?? "";
     expect(expansions).toContain("author_id");
     expect(expansions).toContain("attachments.media_keys");


### PR DESCRIPTION
## Summary
This PR changes the default behavior to include retweets by default and adds support for `--exclude-retweets` and `--exclude-replies` flags to give users more control over tweet filtering.

## Key Changes
- **Default behavior**: Changed `includeRetweets` default from `false` to `true`, meaning retweets are now included by default
- **New exclude flags**: Added `--exclude-retweets` and `--exclude-replies` command-line flags
- **Precedence logic**: When both include and exclude flags are specified, exclude takes precedence
- **API defaults**: Updated `XClient.fetchUserTweets()` to default `includeRetweets` to `true` and adjusted the default exclude filter to only exclude replies (not retweets)

## Implementation Details
- The `parseArgs()` function now checks for exclude flags first, and only applies include flag defaults if exclude flags are not set
- For `includeReplies`, the default remains `false` (replies excluded by default)
- For `includeRetweets`, the new default is `true` (retweets included by default)
- Updated test descriptions and expectations to reflect the new default behavior

https://claude.ai/code/session_01WAbR6bGs9opzCm8rrS3UaN