### PR TITLE
Add support for parsing Twitter/X URLs in username arguments

### DIFF
--- a/src/twcheck/main.ts
+++ b/src/twcheck/main.ts
@@ -63,6 +63,19 @@ export interface RunOutput {
   summary: RunSummary;
 }
 
+export function parseUsername(input: string): string {
+  try {
+    const url = new URL(input);
+    if (url.hostname === "x.com" || url.hostname === "twitter.com") {
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (parts.length > 0) return parts[0];
+    }
+  } catch {
+    // Not a URL
+  }
+  return input.replace(/^@/, "");
+}
+
 export function parseArgs(argv: string[]): RunOptions {
   const { values, positionals } = nodeParseArgs({
     args: argv.slice(2),
@@ -77,7 +90,7 @@ export function parseArgs(argv: string[]): RunOptions {
   });
 
   return {
-    usernames: positionals.map((u) => u.replace(/^@/, "")),
+    usernames: positionals.map(parseUsername),
     statePath: values.state ?? DEFAULT_STATE_PATH,
     includeRetweets: values["exclude-retweets"] ? false : (values["include-retweets"] ?? true),
     includeReplies: values["exclude-replies"] ? false : (values["include-replies"] ?? false),

--- a/test/twcheck/main.test.ts
+++ b/test/twcheck/main.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { PostEntry, RunOptions } from "@/twcheck/main.js";
-import { buildPostEntry, buildRunOutput, parseArgs, processAccount, sortPostsChronologically } from "@/twcheck/main.js";
+import {
+  buildPostEntry,
+  buildRunOutput,
+  parseArgs,
+  parseUsername,
+  processAccount,
+  sortPostsChronologically,
+} from "@/twcheck/main.js";
 import { emptyState, STATE_VERSION } from "@/twcheck/state.js";
 import type { FetchUserTweetsOptions, XClientApi, XTweet, XUser } from "@/twcheck/xClient.js";
 
@@ -49,6 +56,31 @@ describe("parseArgs", () => {
   it("strips a leading @ from usernames", () => {
     const options = parseArgs(makeArgv("@elonmusk"));
     expect(options.usernames).toEqual(["elonmusk"]);
+  });
+
+  it("extracts username from https://x.com/foo URL", () => {
+    const options = parseArgs(makeArgv("https://x.com/elonmusk"));
+    expect(options.usernames).toEqual(["elonmusk"]);
+  });
+});
+
+// ── parseUsername ────────────────────────────────────────────
+
+describe("parseUsername", () => {
+  it("returns plain username as-is", () => {
+    expect(parseUsername("elonmusk")).toBe("elonmusk");
+  });
+
+  it("strips a leading @", () => {
+    expect(parseUsername("@elonmusk")).toBe("elonmusk");
+  });
+
+  it("extracts username from https://x.com/foo", () => {
+    expect(parseUsername("https://x.com/elonmusk")).toBe("elonmusk");
+  });
+
+  it("extracts username from https://twitter.com/foo", () => {
+    expect(parseUsername("https://twitter.com/elonmusk")).toBe("elonmusk");
   });
 });
 


### PR DESCRIPTION
## Summary
This PR adds support for parsing Twitter/X profile URLs in addition to plain usernames and @-prefixed handles. Users can now pass full URLs like `https://x.com/elonmusk` or `https://twitter.com/elonmusk` as arguments, and the username will be automatically extracted.

## Changes
- **New `parseUsername()` function**: Extracts usernames from various input formats:
  - Plain usernames: `elonmusk` → `elonmusk`
  - @-prefixed handles: `@elonmusk` → `elonmusk`
  - X.com URLs: `https://x.com/elonmusk` → `elonmusk`
  - Twitter.com URLs: `https://twitter.com/elonmusk` → `elonmusk`

- **Updated `parseArgs()` function**: Now uses `parseUsername()` to process positional arguments instead of simple regex replacement

- **Comprehensive test coverage**: Added 4 new test cases for `parseUsername()` and 1 additional test for `parseArgs()` to verify URL parsing works end-to-end

## Implementation Details
The `parseUsername()` function uses the native `URL` API to safely parse URLs, gracefully falling back to simple @-stripping for non-URL inputs. This approach handles both x.com and twitter.com domains to support legacy Twitter URLs.

https://claude.ai/code/session_01RtpKH6ds1BddnGoy9t4ijr