### PR TITLE
Rename tweet/retweet terminology to post/repost

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -1,13 +1,13 @@
 import { parseArgs as nodeParseArgs } from "node:util";
 import type { AccountRunResult, XfetchState } from "./state.js";
 import { getAccountState, getDefaultStatePath, loadState, mergeStateAfterRun, saveState } from "./state.js";
-import type { FetchUserTweetsOptions, XClientApi, XError, XTweet, XUser } from "./xClient.js";
+import type { FetchUserPostsOptions, XClientApi, XError, XPost, XUser } from "./xClient.js";
 import { XClient } from "./xClient.js";
 
 export interface RunOptions {
   usernames: string[];
   statePath: string;
-  includeRetweets: boolean;
+  includeReposts: boolean;
   includeReplies: boolean;
   patterns: RegExp[];
   invertMatch: boolean;
@@ -41,7 +41,7 @@ export interface PostEntry {
   media: MediaInfo[];
   urls: UrlInfo[];
   author: AuthorInfo;
-  retweeted_by: AuthorInfo | null;
+  reposted_by: AuthorInfo | null;
 }
 
 export interface ErrorEntry {
@@ -83,8 +83,8 @@ export function parseArgs(argv: string[]): RunOptions {
     args: argv.slice(2),
     options: {
       state: { type: "string" },
-      "include-retweets": { type: "boolean" },
-      "exclude-retweets": { type: "boolean" },
+      "include-reposts": { type: "boolean" },
+      "exclude-reposts": { type: "boolean" },
       "include-replies": { type: "boolean" },
       "exclude-replies": { type: "boolean" },
       regexp: { type: "string", multiple: true, short: "e" },
@@ -106,7 +106,7 @@ export function parseArgs(argv: string[]): RunOptions {
   return {
     usernames: positionals.map(parseUsername),
     statePath: values.state ?? process.env.XFETCH_STATE_FILE ?? getDefaultStatePath(),
-    includeRetweets: values["exclude-retweets"] ? false : (values["include-retweets"] ?? true),
+    includeReposts: values["exclude-reposts"] ? false : (values["include-reposts"] ?? true),
     includeReplies: values["exclude-replies"] ? false : (values["include-replies"] ?? false),
     patterns,
     invertMatch: values["invert-match"] ?? false,
@@ -122,25 +122,25 @@ export function requireBearerToken(): string {
   return token;
 }
 
-export function buildPostEntry(tweet: XTweet): PostEntry {
+export function buildPostEntry(post: XPost): PostEntry {
   return {
-    id: tweet.id,
-    url: `https://x.com/${encodeURIComponent(tweet.author.username)}/status/${tweet.sourceTweetId}`,
-    text: tweet.text,
-    created_at: tweet.createdAt,
-    lang: tweet.lang,
-    media: tweet.media.map((m) => ({
+    id: post.id,
+    url: `https://x.com/${encodeURIComponent(post.author.username)}/status/${post.sourcePostId}`,
+    text: post.text,
+    created_at: post.createdAt,
+    lang: post.lang,
+    media: post.media.map((m) => ({
       type: m.type,
       url: m.url,
       preview_image_url: m.previewImageUrl,
     })),
-    urls: tweet.urls.map((u) => ({
+    urls: post.urls.map((u) => ({
       url: u.url,
       expanded_url: u.expandedUrl,
       display_url: u.displayUrl,
     })),
-    author: toAuthorInfo(tweet.author),
-    retweeted_by: tweet.retweetedBy ? toAuthorInfo(tweet.retweetedBy) : null,
+    author: toAuthorInfo(post.author),
+    reposted_by: post.repostedBy ? toAuthorInfo(post.repostedBy) : null,
   };
 }
 
@@ -203,25 +203,25 @@ export async function processAccount(
   user: XUser,
   state: XfetchState,
   client: XClientApi,
-  options: Pick<RunOptions, "includeRetweets" | "includeReplies" | "patterns" | "invertMatch">,
+  options: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch">,
 ): Promise<ProcessedAccount> {
   const previous = getAccountState(state, username);
   const isFirstRun = !previous || previous.lastSeenId === null;
 
-  const fetchOptions: FetchUserTweetsOptions = {
-    includeRetweets: options.includeRetweets,
+  const fetchOptions: FetchUserPostsOptions = {
+    includeReposts: options.includeReposts,
     includeReplies: options.includeReplies,
   };
 
   if (isFirstRun) {
-    // Baseline run: fetch only the most recent tweet to record as lastSeenId.
+    // Baseline run: fetch only the most recent post to record as lastSeenId.
     fetchOptions.maxResults = 5;
     fetchOptions.maxPages = 1;
   } else {
     fetchOptions.sinceId = previous?.lastSeenId ?? null;
   }
 
-  const result = await client.fetchUserTweets(user.id, fetchOptions);
+  const result = await client.fetchUserPosts(user.id, fetchOptions);
 
   if (!result.ok) {
     return {
@@ -237,10 +237,10 @@ export async function processAccount(
     };
   }
 
-  const tweets = result.tweets;
+  const posts = result.posts;
 
   if (isFirstRun) {
-    const newestId = tweets[0]?.id ?? null;
+    const newestId = posts[0]?.id ?? null;
     return {
       accountResult: { username, status: "baseline_established", newLastSeenId: newestId },
       posts: [],
@@ -249,12 +249,12 @@ export async function processAccount(
     };
   }
 
-  const newestId = tweets[0]?.id ?? previous?.lastSeenId ?? null;
+  const newestId = posts[0]?.id ?? previous?.lastSeenId ?? null;
 
   return {
     accountResult: { username, status: "ok", newLastSeenId: newestId },
     posts: filterPostsByPattern(
-      tweets.map((tweet) => buildPostEntry(tweet)),
+      posts.map((post) => buildPostEntry(post)),
       options.patterns,
       options.invertMatch,
     ),

--- a/src/xfetch/xClient.ts
+++ b/src/xfetch/xClient.ts
@@ -31,42 +31,42 @@ export interface XMediaEntry {
 }
 
 export interface XUrlEntry {
-  url: string; // the t.co URL as it appears in the tweet text
+  url: string; // the t.co URL as it appears in the post text
   expandedUrl: string; // the fully expanded destination URL
   displayUrl: string; // the display-friendly URL shown in clients
 }
 
-export interface XTweet {
+export interface XPost {
   id: string;
-  sourceTweetId: string; // original tweet id; same as `id` unless this is a retweet
+  sourcePostId: string; // original post id; same as `id` unless this is a repost
   text: string;
   createdAt: string;
   lang: string | null;
-  author: XUser; // effective author: for retweets this is the original poster
-  retweetedBy: XUser | null; // set only when the timeline entry is a retweet
+  author: XUser; // effective author: for reposts this is the original poster
+  repostedBy: XUser | null; // set only when the timeline entry is a repost
   media: XMediaEntry[];
   urls: XUrlEntry[];
 }
 
-export interface FetchUserTweetsOptions {
+export interface FetchUserPostsOptions {
   sinceId?: string | null;
   maxResults?: number;
   maxPages?: number;
-  includeRetweets?: boolean;
+  includeReposts?: boolean;
   includeReplies?: boolean;
 }
 
-export interface FetchUserTweetsSuccess {
+export interface FetchUserPostsSuccess {
   ok: true;
-  tweets: XTweet[];
+  posts: XPost[];
 }
 
-export interface FetchUserTweetsFailure {
+export interface FetchUserPostsFailure {
   ok: false;
   error: XError;
 }
 
-export type FetchUserTweetsResult = FetchUserTweetsSuccess | FetchUserTweetsFailure;
+export type FetchUserPostsResult = FetchUserPostsSuccess | FetchUserPostsFailure;
 
 export interface LookupUsersSuccess {
   ok: true;
@@ -100,12 +100,12 @@ interface RawUrlEntity {
   display_url?: string;
 }
 
-interface RawReferencedTweet {
+interface RawReferencedPost {
   type: string; // "retweeted" | "quoted" | "replied_to"
   id: string;
 }
 
-interface RawTweet {
+interface RawPost {
   id: string;
   text: string;
   created_at: string;
@@ -113,14 +113,14 @@ interface RawTweet {
   lang?: string;
   attachments?: { media_keys?: string[] };
   entities?: { urls?: RawUrlEntity[] };
-  referenced_tweets?: RawReferencedTweet[];
+  referenced_tweets?: RawReferencedPost[];
 }
 
-interface RawTweetsResponse {
-  data?: RawTweet[];
+interface RawPostsResponse {
+  data?: RawPost[];
   includes?: {
     media?: RawMedia[];
-    tweets?: RawTweet[];
+    tweets?: RawPost[];
     users?: RawUser[];
   };
   meta?: {
@@ -208,7 +208,7 @@ function mapRawMedia(mediaKeys: readonly string[] | undefined, mediaMap: Readonl
     .filter((m): m is XMediaEntry => m !== null);
 }
 
-function mapRawUrls(entities: RawTweet["entities"]): XUrlEntry[] {
+function mapRawUrls(entities: RawPost["entities"]): XUrlEntry[] {
   return (entities?.urls ?? [])
     .map((entry): XUrlEntry | null => {
       if (!entry.expanded_url) return null;
@@ -222,44 +222,44 @@ function mapRawUrls(entities: RawTweet["entities"]): XUrlEntry[] {
 }
 
 /**
- * Converts a single raw timeline entry into the internal {@link XTweet}
- * shape, resolving retweet indirection so callers always see the original
+ * Converts a single raw timeline entry into the internal {@link XPost}
+ * shape, resolving repost indirection so callers always see the original
  * author and full content. Exported for test setup; not intended as a
  * general-purpose public helper.
  *
- * Quote tweets (`type === "quoted"`) and replies (`type === "replied_to"`)
+ * Quote posts (`type === "quoted"`) and replies (`type === "replied_to"`)
  * intentionally pass through unchanged: the quoter/replier is the
  * effective author because the visible content is their own commentary,
- * not the referenced tweet.
+ * not the referenced post.
  */
-export function buildXTweetFromRaw(
-  raw: RawTweet,
+export function buildXPostFromRaw(
+  raw: RawPost,
   usersMap: ReadonlyMap<string, XUser>,
-  includedTweetsMap: ReadonlyMap<string, RawTweet>,
+  includedPostsMap: ReadonlyMap<string, RawPost>,
   mediaMap: ReadonlyMap<string, RawMedia>,
-): XTweet {
-  const retweetRef = raw.referenced_tweets?.find((r) => r.type === "retweeted");
-  const original = retweetRef ? includedTweetsMap.get(retweetRef.id) : undefined;
-  const isRetweet = original !== undefined;
+): XPost {
+  const repostRef = raw.referenced_tweets?.find((r) => r.type === "retweeted");
+  const original = repostRef ? includedPostsMap.get(repostRef.id) : undefined;
+  const isRepost = original !== undefined;
 
-  // For retweets the visible content (text/media/urls/author) comes from
-  // the referenced original tweet, while the timeline entry (id,
+  // For reposts the visible content (text/media/urls/author) comes from
+  // the referenced original post, while the timeline entry (id,
   // created_at) stays the outer one so since_id tracking still works and
-  // the retweet event appears at its actual time in chronological sort.
+  // the repost event appears at its actual time in chronological sort.
   const contentSource = original ?? raw;
 
   const author = resolveXUser(contentSource.author_id, usersMap);
-  const retweetedBy =
-    isRetweet && raw.author_id !== contentSource.author_id ? resolveXUser(raw.author_id, usersMap) : null;
+  const repostedBy =
+    isRepost && raw.author_id !== contentSource.author_id ? resolveXUser(raw.author_id, usersMap) : null;
 
   return {
     id: raw.id,
-    sourceTweetId: contentSource.id,
+    sourcePostId: contentSource.id,
     text: contentSource.text,
     createdAt: raw.created_at,
     lang: contentSource.lang ?? null,
     author,
-    retweetedBy,
+    repostedBy,
     media: mapRawMedia(contentSource.attachments?.media_keys, mediaMap),
     urls: mapRawUrls(contentSource.entities),
   };
@@ -323,16 +323,16 @@ export class XClient {
     return { ok: true, result: { found, missing: Array.from(missing) } };
   }
 
-  async fetchUserTweets(userId: string, options: FetchUserTweetsOptions = {}): Promise<FetchUserTweetsResult> {
+  async fetchUserPosts(userId: string, options: FetchUserPostsOptions = {}): Promise<FetchUserPostsResult> {
     const {
       sinceId,
       maxResults = DEFAULT_PAGE_SIZE,
       maxPages = DEFAULT_MAX_PAGES,
-      includeRetweets = true,
+      includeReposts = true,
       includeReplies = false,
     } = options;
 
-    const tweets: XTweet[] = [];
+    const posts: XPost[] = [];
     let nextToken: string | undefined;
     let page = 0;
 
@@ -347,7 +347,7 @@ export class XClient {
       url.searchParams.set("media.fields", "url,preview_image_url,type");
       url.searchParams.set("user.fields", "id,username,name,profile_image_url");
       const excludes: string[] = [];
-      if (!includeRetweets) excludes.push("retweets");
+      if (!includeReposts) excludes.push("retweets");
       if (!includeReplies) excludes.push("replies");
       if (excludes.length > 0) {
         url.searchParams.set("exclude", excludes.join(","));
@@ -374,9 +374,9 @@ export class XClient {
         return { ok: false, error: classifyHttpError(response.status, response.headers, text) };
       }
 
-      let body: RawTweetsResponse;
+      let body: RawPostsResponse;
       try {
-        body = (await response.json()) as RawTweetsResponse;
+        body = (await response.json()) as RawPostsResponse;
       } catch (error) {
         return {
           ok: false,
@@ -402,15 +402,15 @@ export class XClient {
         });
       }
 
-      const includedTweetsMap = new Map<string, RawTweet>();
-      for (const includedTweet of body.includes?.tweets ?? []) {
-        includedTweetsMap.set(includedTweet.id, includedTweet);
+      const includedPostsMap = new Map<string, RawPost>();
+      for (const includedPost of body.includes?.tweets ?? []) {
+        includedPostsMap.set(includedPost.id, includedPost);
       }
 
       for (const raw of body.data ?? []) {
-        const tweet = buildXTweetFromRaw(raw, usersMap, includedTweetsMap, mediaMap);
-        if (tweet) {
-          tweets.push(tweet);
+        const post = buildXPostFromRaw(raw, usersMap, includedPostsMap, mediaMap);
+        if (post) {
+          posts.push(post);
         }
       }
 
@@ -421,7 +421,7 @@ export class XClient {
       }
     }
 
-    return { ok: true, tweets };
+    return { ok: true, posts };
   }
 
   private buildHeaders(): HeadersInit {
@@ -437,4 +437,4 @@ export class XClient {
  * tests or wrappers that only need the two HTTP methods without the private
  * bearer-token state.
  */
-export type XClientApi = Pick<XClient, "lookupUsers" | "fetchUserTweets">;
+export type XClientApi = Pick<XClient, "lookupUsers" | "fetchUserPosts">;

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -10,7 +10,7 @@ import {
   sortPostsChronologically,
 } from "@/xfetch/main.js";
 import { emptyState, STATE_VERSION } from "@/xfetch/state.js";
-import type { FetchUserTweetsOptions, XClientApi, XTweet, XUser } from "@/xfetch/xClient.js";
+import type { FetchUserPostsOptions, XClientApi, XPost, XUser } from "@/xfetch/xClient.js";
 
 // ── parseArgs ────────────────────────────────────────────────
 
@@ -34,31 +34,31 @@ describe("parseArgs", () => {
     expect(options).toEqual({
       usernames: ["elonmusk", "sama"],
       statePath: "/xdg/state/xfetch/state.json",
-      includeRetweets: true,
+      includeReposts: true,
       includeReplies: false,
       patterns: [],
       invertMatch: false,
     });
   });
 
-  it("parses --include-retweets and --include-replies flags", () => {
-    const options = parseArgs(makeArgv("--state", "/tmp/s.json", "--include-retweets", "--include-replies", "elon"));
+  it("parses --include-reposts and --include-replies flags", () => {
+    const options = parseArgs(makeArgv("--state", "/tmp/s.json", "--include-reposts", "--include-replies", "elon"));
     expect(options).toEqual({
       usernames: ["elon"],
       statePath: "/tmp/s.json",
-      includeRetweets: true,
+      includeReposts: true,
       includeReplies: true,
       patterns: [],
       invertMatch: false,
     });
   });
 
-  it("parses --exclude-retweets and --exclude-replies flags", () => {
-    const options = parseArgs(makeArgv("--exclude-retweets", "--exclude-replies", "elon"));
+  it("parses --exclude-reposts and --exclude-replies flags", () => {
+    const options = parseArgs(makeArgv("--exclude-reposts", "--exclude-replies", "elon"));
     expect(options).toEqual({
       usernames: ["elon"],
       statePath: "/xdg/state/xfetch/state.json",
-      includeRetweets: false,
+      includeReposts: false,
       includeReplies: false,
       patterns: [],
       invertMatch: false,
@@ -83,8 +83,8 @@ describe("parseArgs", () => {
   });
 
   it("exclude-* takes precedence over include-* when both are set", () => {
-    const rt = parseArgs(makeArgv("--include-retweets", "--exclude-retweets", "elon"));
-    expect(rt.includeRetweets).toBe(false);
+    const rt = parseArgs(makeArgv("--include-reposts", "--exclude-reposts", "elon"));
+    expect(rt.includeReposts).toBe(false);
     const rep = parseArgs(makeArgv("--include-replies", "--exclude-replies", "elon"));
     expect(rep.includeReplies).toBe(false);
   });
@@ -162,30 +162,30 @@ const sampleUser: XUser = {
   profileImageUrl: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
 };
 
-const makeTweet = (id: string, createdAt: string, extra: Partial<XTweet> = {}): XTweet => ({
+const makePost = (id: string, createdAt: string, extra: Partial<XPost> = {}): XPost => ({
   id,
-  sourceTweetId: id,
-  text: `tweet ${id}`,
+  sourcePostId: id,
+  text: `post ${id}`,
   createdAt,
   lang: "en",
   author: sampleUser,
-  retweetedBy: null,
+  repostedBy: null,
   media: [],
   urls: [],
   ...extra,
 });
 
 describe("buildPostEntry", () => {
-  it("builds the post url from the tweet author username and sourceTweetId", () => {
-    const entry = buildPostEntry(makeTweet("9001", "2026-04-11T12:00:00.000Z"));
+  it("builds the post url from the post author username and sourcePostId", () => {
+    const entry = buildPostEntry(makePost("9001", "2026-04-11T12:00:00.000Z"));
     expect(entry.url).toBe("https://x.com/elonmusk/status/9001");
   });
 
   it("embeds author and media", () => {
-    const tweet = makeTweet("5", "2026-04-11T12:00:00.000Z", {
+    const post = makePost("5", "2026-04-11T12:00:00.000Z", {
       media: [{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", previewImageUrl: null, mediaKey: "k1" }],
     });
-    const entry = buildPostEntry(tweet);
+    const entry = buildPostEntry(post);
     expect(entry.author).toEqual({
       id: "123",
       username: "elonmusk",
@@ -195,13 +195,13 @@ describe("buildPostEntry", () => {
     expect(entry.media).toEqual([{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", preview_image_url: null }]);
   });
 
-  it("defaults retweeted_by to null for normal tweets", () => {
-    const entry = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"));
-    expect(entry.retweeted_by).toBeNull();
+  it("defaults reposted_by to null for normal posts", () => {
+    const entry = buildPostEntry(makePost("1", "2026-04-11T12:00:00.000Z"));
+    expect(entry.reposted_by).toBeNull();
   });
 
-  it("maps tweet entities.urls to post urls with snake_case keys", () => {
-    const tweet = makeTweet("5", "2026-04-11T12:00:00.000Z", {
+  it("maps post entities.urls to post urls with snake_case keys", () => {
+    const post = makePost("5", "2026-04-11T12:00:00.000Z", {
       urls: [
         {
           url: "https://t.co/abc",
@@ -210,36 +210,36 @@ describe("buildPostEntry", () => {
         },
       ],
     });
-    const entry = buildPostEntry(tweet);
+    const entry = buildPostEntry(post);
     expect(entry.urls).toEqual([
       { url: "https://t.co/abc", expanded_url: "https://example.com/page", display_url: "example.com/page" },
     ]);
   });
 
-  it("returns an empty urls array when the tweet has no link entities", () => {
-    const entry = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"));
+  it("returns an empty urls array when the post has no link entities", () => {
+    const entry = buildPostEntry(makePost("1", "2026-04-11T12:00:00.000Z"));
     expect(entry.urls).toEqual([]);
   });
 
-  it("surfaces the original author in author and the retweeter in retweeted_by for retweets", () => {
+  it("surfaces the original author in author and the reposter in reposted_by for reposts", () => {
     const originalAuthor: XUser = {
       id: "999",
       username: "sama",
       name: "Sam",
       profileImageUrl: "https://pbs.twimg.com/profile_images/2/s_400x400.jpg",
     };
-    const tweet: XTweet = {
-      id: "1700", // retweet entry id on elonmusk's timeline
-      sourceTweetId: "1500", // original tweet id by sama
+    const post: XPost = {
+      id: "1700", // repost entry id on elonmusk's timeline
+      sourcePostId: "1500", // original post id by sama
       text: "full original text",
       createdAt: "2026-04-11T12:00:00.000Z",
       lang: "en",
       author: originalAuthor,
-      retweetedBy: sampleUser,
+      repostedBy: sampleUser,
       media: [],
       urls: [],
     };
-    const entry = buildPostEntry(tweet);
+    const entry = buildPostEntry(post);
     expect(entry.id).toBe("1700");
     expect(entry.url).toBe("https://x.com/sama/status/1500");
     expect(entry.text).toBe("full original text");
@@ -249,7 +249,7 @@ describe("buildPostEntry", () => {
       name: "Sam",
       profile_image_url: "https://pbs.twimg.com/profile_images/2/s_400x400.jpg",
     });
-    expect(entry.retweeted_by).toEqual({
+    expect(entry.reposted_by).toEqual({
       id: "123",
       username: "elonmusk",
       name: "Elon",
@@ -260,9 +260,9 @@ describe("buildPostEntry", () => {
 
 describe("sortPostsChronologically", () => {
   it("sorts posts from multiple authors in ascending created_at order", () => {
-    const a = buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z"), sampleUser);
-    const b = buildPostEntry(makeTweet("2", "2026-04-11T11:00:00.000Z"), sampleUser);
-    const c = buildPostEntry(makeTweet("3", "2026-04-11T13:00:00.000Z"), sampleUser);
+    const a = buildPostEntry(makePost("1", "2026-04-11T12:00:00.000Z"), sampleUser);
+    const b = buildPostEntry(makePost("2", "2026-04-11T11:00:00.000Z"), sampleUser);
+    const c = buildPostEntry(makePost("3", "2026-04-11T13:00:00.000Z"), sampleUser);
     const sorted = sortPostsChronologically([a, b, c]);
     expect(sorted.map((p) => p.id)).toEqual(["2", "1", "3"]);
   });
@@ -271,48 +271,48 @@ describe("sortPostsChronologically", () => {
 // ── filterPostsByPattern ─────────────────────────────────────
 
 describe("filterPostsByPattern", () => {
-  const makePost = (text: string): PostEntry => ({
-    ...buildPostEntry(makeTweet("1", "2026-04-11T12:00:00.000Z", { text })),
+  const makeTestPost = (text: string): PostEntry => ({
+    ...buildPostEntry(makePost("1", "2026-04-11T12:00:00.000Z", { text })),
     text,
   });
 
   it("returns all posts when patterns is empty", () => {
-    const posts = [makePost("hello world"), makePost("foo bar")];
+    const posts = [makeTestPost("hello world"), makeTestPost("foo bar")];
     expect(filterPostsByPattern(posts, [], false)).toEqual(posts);
   });
 
   it("keeps only posts that match any pattern when invertMatch is false", () => {
-    const posts = [makePost("hello world"), makePost("foo bar"), makePost("hello foo")];
+    const posts = [makeTestPost("hello world"), makeTestPost("foo bar"), makeTestPost("hello foo")];
     const result = filterPostsByPattern(posts, [/hello/], false);
     expect(result.map((p) => p.text)).toEqual(["hello world", "hello foo"]);
   });
 
   it("excludes posts that match any pattern when invertMatch is true", () => {
-    const posts = [makePost("hello world"), makePost("foo bar"), makePost("hello foo")];
+    const posts = [makeTestPost("hello world"), makeTestPost("foo bar"), makeTestPost("hello foo")];
     const result = filterPostsByPattern(posts, [/hello/], true);
     expect(result.map((p) => p.text)).toEqual(["foo bar"]);
   });
 
   it("matches if any of multiple patterns match (OR semantics)", () => {
-    const posts = [makePost("apple pie"), makePost("banana split"), makePost("cherry cake")];
+    const posts = [makeTestPost("apple pie"), makeTestPost("banana split"), makeTestPost("cherry cake")];
     const result = filterPostsByPattern(posts, [/apple/, /banana/], false);
     expect(result.map((p) => p.text)).toEqual(["apple pie", "banana split"]);
   });
 
   it("excludes posts matching any pattern when invertMatch is true with multiple patterns", () => {
-    const posts = [makePost("apple pie"), makePost("banana split"), makePost("cherry cake")];
+    const posts = [makeTestPost("apple pie"), makeTestPost("banana split"), makeTestPost("cherry cake")];
     const result = filterPostsByPattern(posts, [/apple/, /banana/], true);
     expect(result.map((p) => p.text)).toEqual(["cherry cake"]);
   });
 
   it("matches case-sensitively", () => {
-    const posts = [makePost("Hello World"), makePost("hello world")];
+    const posts = [makeTestPost("Hello World"), makeTestPost("hello world")];
     const result = filterPostsByPattern(posts, [/hello/], false);
     expect(result.map((p) => p.text)).toEqual(["hello world"]);
   });
 
   it("returns empty array when no posts match", () => {
-    const posts = [makePost("foo"), makePost("bar")];
+    const posts = [makeTestPost("foo"), makeTestPost("bar")];
     expect(filterPostsByPattern(posts, [/zzz/], false)).toEqual([]);
   });
 });
@@ -324,8 +324,8 @@ describe("buildRunOutput", () => {
 
   it("builds the full output shape with summary counts", () => {
     const posts: PostEntry[] = [
-      buildPostEntry(makeTweet("100", "2026-04-11T11:00:00.000Z"), sampleUser),
-      buildPostEntry(makeTweet("101", "2026-04-11T12:00:00.000Z"), sampleUser),
+      buildPostEntry(makePost("100", "2026-04-11T11:00:00.000Z"), sampleUser),
+      buildPostEntry(makePost("101", "2026-04-11T12:00:00.000Z"), sampleUser),
     ];
     const output = buildRunOutput(NOW, 3, 1, posts, [
       { username: "ghost", code: "account_not_found", message: "not found" },
@@ -344,18 +344,18 @@ describe("buildRunOutput", () => {
 
 // ── processAccount ───────────────────────────────────────────
 
-function makeClient(fetchImpl: (userId: string, opts?: FetchUserTweetsOptions) => Promise<XTweet[]>): XClientApi {
+function makeClient(fetchImpl: (userId: string, opts?: FetchUserPostsOptions) => Promise<XPost[]>): XClientApi {
   return {
     lookupUsers: async () => ({ ok: true, result: { found: new Map(), missing: [] } }),
-    fetchUserTweets: async (userId, opts) => {
-      const tweets = await fetchImpl(userId, opts);
-      return { ok: true as const, tweets };
+    fetchUserPosts: async (userId, opts) => {
+      const posts = await fetchImpl(userId, opts);
+      return { ok: true as const, posts };
     },
   };
 }
 
-const baseOptions: Pick<RunOptions, "includeRetweets" | "includeReplies" | "patterns" | "invertMatch"> = {
-  includeRetweets: true,
+const baseOptions: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch"> = {
+  includeReposts: true,
   includeReplies: false,
   patterns: [],
   invertMatch: false,
@@ -363,10 +363,10 @@ const baseOptions: Pick<RunOptions, "includeRetweets" | "includeReplies" | "patt
 
 describe("processAccount", () => {
   it("returns baseline_established on first run without producing posts", async () => {
-    let capturedOpts: FetchUserTweetsOptions | undefined;
+    let capturedOpts: FetchUserPostsOptions | undefined;
     const client = makeClient(async (_id, opts) => {
       capturedOpts = opts;
-      return [makeTweet("999", "2026-04-11T12:00:00.000Z")];
+      return [makePost("999", "2026-04-11T12:00:00.000Z")];
     });
     const state = emptyState();
     const processed = await processAccount("elonmusk", sampleUser, state, client, baseOptions);
@@ -381,10 +381,10 @@ describe("processAccount", () => {
   });
 
   it("uses the cached lastSeenId as since_id on subsequent runs", async () => {
-    let capturedOpts: FetchUserTweetsOptions | undefined;
+    let capturedOpts: FetchUserPostsOptions | undefined;
     const client = makeClient(async (_id, opts) => {
       capturedOpts = opts;
-      return [makeTweet("200", "2026-04-11T12:00:00.000Z"), makeTweet("199", "2026-04-11T11:00:00.000Z")];
+      return [makePost("200", "2026-04-11T12:00:00.000Z"), makePost("199", "2026-04-11T11:00:00.000Z")];
     });
     const state = {
       version: STATE_VERSION as 1,
@@ -405,7 +405,7 @@ describe("processAccount", () => {
     expect(processed.posts.map((p) => p.id)).toEqual(["200", "199"]);
   });
 
-  it("preserves cached lastSeenId on a subsequent run with no new tweets", async () => {
+  it("preserves cached lastSeenId on a subsequent run with no new posts", async () => {
     const client = makeClient(async () => []);
     const state = {
       version: STATE_VERSION as 1,
@@ -424,10 +424,10 @@ describe("processAccount", () => {
     expect(processed.baselineEstablished).toBe(false);
   });
 
-  it("returns an error entry when fetchUserTweets fails", async () => {
+  it("returns an error entry when fetchUserPosts fails", async () => {
     const client: XClientApi = {
       lookupUsers: async () => ({ ok: true, result: { found: new Map(), missing: [] } }),
-      fetchUserTweets: async () => ({
+      fetchUserPosts: async () => ({
         ok: false,
         error: { code: "rate_limited", message: "429", resetAt: "2026-04-11T13:00:00.000Z" },
       }),
@@ -449,7 +449,7 @@ describe("processAccount", () => {
     expect(processed.posts).toEqual([]);
   });
 
-  it("returns empty baseline when account has zero tweets", async () => {
+  it("returns empty baseline when account has zero posts", async () => {
     const client = makeClient(async () => []);
     const processed = await processAccount("elonmusk", sampleUser, emptyState(), client, baseOptions);
     expect(processed.accountResult).toEqual({
@@ -461,8 +461,8 @@ describe("processAccount", () => {
 
   it("filters posts by pattern when patterns are specified", async () => {
     const client = makeClient(async () => [
-      makeTweet("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
-      makeTweet("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
+      makePost("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
+      makePost("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
     ]);
     const state = {
       version: STATE_VERSION as 1,
@@ -480,8 +480,8 @@ describe("processAccount", () => {
 
   it("excludes posts matching pattern when invertMatch is true", async () => {
     const client = makeClient(async () => [
-      makeTweet("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
-      makeTweet("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
+      makePost("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
+      makePost("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
     ]);
     const state = {
       version: STATE_VERSION as 1,
@@ -497,12 +497,12 @@ describe("processAccount", () => {
     expect(processed.posts.map((p) => p.text)).toEqual(["foo bar"]);
   });
 
-  it("tracks newLastSeenId from the newest fetched tweet even when it is excluded by the filter", async () => {
-    // Tweet "200" is the newest but matches the exclusion pattern.
+  it("tracks newLastSeenId from the newest fetched post even when it is excluded by the filter", async () => {
+    // Post "200" is the newest but matches the exclusion pattern.
     // It must still advance newLastSeenId so the next run does not re-fetch it.
     const client = makeClient(async () => [
-      makeTweet("200", "2026-04-11T12:00:00.000Z", { text: "spam content" }),
-      makeTweet("199", "2026-04-11T11:00:00.000Z", { text: "useful content" }),
+      makePost("200", "2026-04-11T12:00:00.000Z", { text: "spam content" }),
+      makePost("199", "2026-04-11T11:00:00.000Z", { text: "useful content" }),
     ]);
     const state = {
       version: STATE_VERSION as 1,

--- a/test/xfetch/xClient.test.ts
+++ b/test/xfetch/xClient.test.ts
@@ -143,7 +143,7 @@ describe("XClient.lookupUsers", () => {
   });
 });
 
-describe("XClient.fetchUserTweets", () => {
+describe("XClient.fetchUserPosts", () => {
   let fetchMock: FetchMock;
 
   beforeEach(() => {
@@ -158,7 +158,7 @@ describe("XClient.fetchUserTweets", () => {
   it("passes since_id, max_results and default excludes (replies only by default)", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ data: [], meta: { result_count: 0 } }));
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("123", { sinceId: "999" });
+    const result = await client.fetchUserPosts("123", { sinceId: "999" });
     expect(result.ok).toBe(true);
 
     const url = fetchMock.mock.calls[0][0] as URL;
@@ -180,7 +180,7 @@ describe("XClient.fetchUserTweets", () => {
   it("omits exclude when both include flags are set", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ data: [], meta: { result_count: 0 } }));
     const client = new XClient("token");
-    await client.fetchUserTweets("123", { includeRetweets: true, includeReplies: true });
+    await client.fetchUserPosts("123", { includeReposts: true, includeReplies: true });
     const url = fetchMock.mock.calls[0][0] as URL;
     expect(url.searchParams.get("exclude")).toBeNull();
   });
@@ -206,11 +206,11 @@ describe("XClient.fetchUserTweets", () => {
       }),
     );
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    expect(result.tweets).toHaveLength(1);
-    expect(result.tweets[0].media).toEqual([
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0].media).toEqual([
       {
         type: "photo",
         url: "https://pbs.twimg.com/media/m1.jpg",
@@ -218,13 +218,13 @@ describe("XClient.fetchUserTweets", () => {
         mediaKey: "m1",
       },
     ]);
-    expect(result.tweets[0].lang).toBe("en");
-    expect(result.tweets[0].author.username).toBe("elonmusk");
-    expect(result.tweets[0].retweetedBy).toBeNull();
-    expect(result.tweets[0].sourceTweetId).toBe("100");
+    expect(result.posts[0].lang).toBe("en");
+    expect(result.posts[0].author.username).toBe("elonmusk");
+    expect(result.posts[0].repostedBy).toBeNull();
+    expect(result.posts[0].sourcePostId).toBe("100");
   });
 
-  it("maps entities.urls to XTweet.urls", async () => {
+  it("maps entities.urls to XPost.urls", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         data: [
@@ -251,10 +251,10 @@ describe("XClient.fetchUserTweets", () => {
       }),
     );
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    expect(result.tweets[0].urls).toEqual([
+    expect(result.posts[0].urls).toEqual([
       {
         url: "https://t.co/abc",
         expandedUrl: "https://example.com/page",
@@ -263,7 +263,7 @@ describe("XClient.fetchUserTweets", () => {
     ]);
   });
 
-  it("returns an empty urls array when the tweet has no entities field", async () => {
+  it("returns an empty urls array when the post has no entities field", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         data: [
@@ -278,13 +278,13 @@ describe("XClient.fetchUserTweets", () => {
       }),
     );
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    expect(result.tweets[0].urls).toEqual([]);
+    expect(result.posts[0].urls).toEqual([]);
   });
 
-  it("resolves retweets from includes and swaps the author with the original poster", async () => {
+  it("resolves reposts from includes and swaps the author with the original poster", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         data: [
@@ -327,23 +327,23 @@ describe("XClient.fetchUserTweets", () => {
     );
 
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("elon_id", { includeRetweets: true });
+    const result = await client.fetchUserPosts("elon_id", { includeReposts: true });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    expect(result.tweets).toHaveLength(1);
-    const tweet = result.tweets[0];
-    expect(tweet.id).toBe("1700"); // retweet entry id stays as the output id for since_id tracking
-    expect(tweet.sourceTweetId).toBe("1500"); // original id for URL generation
-    expect(tweet.text).toBe("full original text from sama");
-    expect(tweet.createdAt).toBe("2026-04-11T12:00:00.000Z"); // retweet time, not original
-    expect(tweet.lang).toBe("en");
-    expect(tweet.author.username).toBe("sama");
-    expect(tweet.retweetedBy?.username).toBe("elonmusk");
-    expect(tweet.media.map((m) => m.mediaKey)).toEqual(["m9"]);
-    expect(tweet.urls.map((u) => u.expandedUrl)).toEqual(["https://example.com/page"]);
+    expect(result.posts).toHaveLength(1);
+    const post = result.posts[0];
+    expect(post.id).toBe("1700"); // repost entry id stays as the output id for since_id tracking
+    expect(post.sourcePostId).toBe("1500"); // original id for URL generation
+    expect(post.text).toBe("full original text from sama");
+    expect(post.createdAt).toBe("2026-04-11T12:00:00.000Z"); // repost time, not original
+    expect(post.lang).toBe("en");
+    expect(post.author.username).toBe("sama");
+    expect(post.repostedBy?.username).toBe("elonmusk");
+    expect(post.media.map((m) => m.mediaKey)).toEqual(["m9"]);
+    expect(post.urls.map((u) => u.expandedUrl)).toEqual(["https://example.com/page"]);
   });
 
-  it("falls back to the retweeter as author when the referenced tweet is missing from includes", async () => {
+  it("falls back to the reposter as author when the referenced post is missing from includes", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         data: [
@@ -363,38 +363,38 @@ describe("XClient.fetchUserTweets", () => {
     );
 
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("elon_id", { includeRetweets: true });
+    const result = await client.fetchUserPosts("elon_id", { includeReposts: true });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    const tweet = result.tweets[0];
-    expect(tweet.author.username).toBe("elonmusk");
-    expect(tweet.retweetedBy).toBeNull();
-    expect(tweet.text).toBe("RT @sama: truncated…");
-    expect(tweet.sourceTweetId).toBe("1700");
+    const post = result.posts[0];
+    expect(post.author.username).toBe("elonmusk");
+    expect(post.repostedBy).toBeNull();
+    expect(post.text).toBe("RT @sama: truncated…");
+    expect(post.sourcePostId).toBe("1700");
   });
 
   it("follows pagination_token up to maxPages", async () => {
-    const page1Tweets = Array.from({ length: 5 }, (_, i) => ({
+    const page1Posts = Array.from({ length: 5 }, (_, i) => ({
       id: `${100 + i}`,
       text: `t${i}`,
       created_at: "2026-04-11T00:00:00.000Z",
       author_id: "1",
     }));
-    const page2Tweets = Array.from({ length: 3 }, (_, i) => ({
+    const page2Posts = Array.from({ length: 3 }, (_, i) => ({
       id: `${200 + i}`,
       text: `t${i}`,
       created_at: "2026-04-11T00:00:00.000Z",
       author_id: "1",
     }));
     fetchMock
-      .mockResolvedValueOnce(jsonResponse({ data: page1Tweets, meta: { result_count: 5, next_token: "tok-1" } }))
-      .mockResolvedValueOnce(jsonResponse({ data: page2Tweets, meta: { result_count: 3 } }));
+      .mockResolvedValueOnce(jsonResponse({ data: page1Posts, meta: { result_count: 5, next_token: "tok-1" } }))
+      .mockResolvedValueOnce(jsonResponse({ data: page2Posts, meta: { result_count: 3 } }));
 
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1", { maxResults: 5, maxPages: 3 });
+    const result = await client.fetchUserPosts("1", { maxResults: 5, maxPages: 3 });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unexpected error");
-    expect(result.tweets).toHaveLength(8);
+    expect(result.posts).toHaveLength(8);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     const firstUrl = fetchMock.mock.calls[0][0] as URL;
@@ -416,7 +416,7 @@ describe("XClient.fetchUserTweets", () => {
     fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(makePage())));
 
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1", { maxResults: 5, maxPages: 2 });
+    const result = await client.fetchUserPosts("1", { maxResults: 5, maxPages: 2 });
     expect(result.ok).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -424,7 +424,7 @@ describe("XClient.fetchUserTweets", () => {
   it("classifies 429 as rate_limited and extracts reset time", async () => {
     fetchMock.mockResolvedValueOnce(errorResponse(429, "slow down", { "x-rate-limit-reset": "1712000000" }));
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unexpected ok");
     expect(result.error.code).toBe("rate_limited");
@@ -434,7 +434,7 @@ describe("XClient.fetchUserTweets", () => {
   it("classifies 404 as account_not_found", async () => {
     fetchMock.mockResolvedValueOnce(errorResponse(404));
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unexpected ok");
     expect(result.error.code).toBe("account_not_found");
@@ -443,7 +443,7 @@ describe("XClient.fetchUserTweets", () => {
   it("classifies 500 as fetch_failed", async () => {
     fetchMock.mockResolvedValueOnce(errorResponse(500));
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unexpected ok");
     expect(result.error.code).toBe("fetch_failed");
@@ -452,7 +452,7 @@ describe("XClient.fetchUserTweets", () => {
   it("maps network errors to fetch_failed", async () => {
     fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
     const client = new XClient("token");
-    const result = await client.fetchUserTweets("1");
+    const result = await client.fetchUserPosts("1");
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unexpected ok");
     expect(result.error.code).toBe("fetch_failed");


### PR DESCRIPTION
This PR updates the codebase to use more inclusive terminology, replacing "tweet"/"retweet" with "post"/"repost" throughout the xfetch module.

## Summary
Updated all references to Twitter-specific terminology to use more generic social media terminology. This includes type names, interface properties, function names, command-line flags, and test descriptions.

## Key Changes
- **Type renames**: `XTweet` → `XPost`, `FetchUserTweetsOptions` → `FetchUserPostsOptions`, `FetchUserTweetsResult` → `FetchUserPostsResult`
- **Property renames**: `sourceTweetId` → `sourcePostId`, `retweetedBy` → `repostedBy`, `retweeted_by` → `reposted_by`
- **Function renames**: `fetchUserTweets()` → `fetchUserPosts()`, `buildXTweetFromRaw()` → `buildXPostFromRaw()`
- **CLI flags**: `--include-retweets`/`--exclude-retweets` → `--include-reposts`/`--exclude-reposts`
- **Configuration**: `includeRetweets` option → `includeReposts`
- **Internal variables**: Updated variable names and comments throughout to use "post" instead of "tweet"
- **Test updates**: Renamed test helper `makeTweet()` → `makePost()` and updated all test descriptions and assertions

## Implementation Details
- All public API interfaces and types have been updated to maintain consistency
- Internal implementation details (like raw API response types) use "post" terminology where appropriate
- Test coverage remains comprehensive with updated assertions and helper functions
- The change is backward-incompatible for API consumers but improves code clarity and inclusivity

https://claude.ai/code/session_01AtwYvzKrRvVJcXYRJZ9XmP