### PR TITLE
Remove lang and urls fields from post data structures

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -26,20 +26,12 @@ export interface MediaInfo {
   preview_image_url: string | null;
 }
 
-export interface UrlInfo {
-  url: string;
-  expanded_url: string;
-  display_url: string;
-}
-
 export interface PostEntry {
   id: string;
   url: string;
   text: string;
   created_at: string;
-  lang: string | null;
   media: MediaInfo[];
-  urls: UrlInfo[];
   author: AuthorInfo;
   reposted_by: AuthorInfo | null;
 }
@@ -128,16 +120,10 @@ export function buildPostEntry(post: XPost): PostEntry {
     url: `https://x.com/${encodeURIComponent(post.author.username)}/status/${post.sourcePostId}`,
     text: post.text,
     created_at: post.createdAt,
-    lang: post.lang,
     media: post.media.map((m) => ({
       type: m.type,
       url: m.url,
       preview_image_url: m.previewImageUrl,
-    })),
-    urls: post.urls.map((u) => ({
-      url: u.url,
-      expanded_url: u.expandedUrl,
-      display_url: u.displayUrl,
     })),
     author: toAuthorInfo(post.author),
     reposted_by: post.repostedBy ? toAuthorInfo(post.repostedBy) : null,

--- a/src/xfetch/xClient.ts
+++ b/src/xfetch/xClient.ts
@@ -30,22 +30,14 @@ export interface XMediaEntry {
   mediaKey: string;
 }
 
-export interface XUrlEntry {
-  url: string; // the t.co URL as it appears in the post text
-  expandedUrl: string; // the fully expanded destination URL
-  displayUrl: string; // the display-friendly URL shown in clients
-}
-
 export interface XPost {
   id: string;
   sourcePostId: string; // original post id; same as `id` unless this is a repost
   text: string;
   createdAt: string;
-  lang: string | null;
   author: XUser; // effective author: for reposts this is the original poster
   repostedBy: XUser | null; // set only when the timeline entry is a repost
   media: XMediaEntry[];
-  urls: XUrlEntry[];
 }
 
 export interface FetchUserPostsOptions {
@@ -94,12 +86,6 @@ interface RawMedia {
   preview_image_url?: string;
 }
 
-interface RawUrlEntity {
-  url: string;
-  expanded_url?: string;
-  display_url?: string;
-}
-
 interface RawReferencedPost {
   type: string; // "retweeted" | "quoted" | "replied_to"
   id: string;
@@ -110,9 +96,7 @@ interface RawPost {
   text: string;
   created_at: string;
   author_id: string;
-  lang?: string;
   attachments?: { media_keys?: string[] };
-  entities?: { urls?: RawUrlEntity[] };
   referenced_tweets?: RawReferencedPost[];
 }
 
@@ -208,19 +192,6 @@ function mapRawMedia(mediaKeys: readonly string[] | undefined, mediaMap: Readonl
     .filter((m): m is XMediaEntry => m !== null);
 }
 
-function mapRawUrls(entities: RawPost["entities"]): XUrlEntry[] {
-  return (entities?.urls ?? [])
-    .map((entry): XUrlEntry | null => {
-      if (!entry.expanded_url) return null;
-      return {
-        url: entry.url,
-        expandedUrl: entry.expanded_url,
-        displayUrl: entry.display_url ?? entry.expanded_url,
-      };
-    })
-    .filter((u): u is XUrlEntry => u !== null);
-}
-
 /**
  * Converts a single raw timeline entry into the internal {@link XPost}
  * shape, resolving repost indirection so callers always see the original
@@ -257,11 +228,9 @@ export function buildXPostFromRaw(
     sourcePostId: contentSource.id,
     text: contentSource.text,
     createdAt: raw.created_at,
-    lang: contentSource.lang ?? null,
     author,
     repostedBy,
     media: mapRawMedia(contentSource.attachments?.media_keys, mediaMap),
-    urls: mapRawUrls(contentSource.entities),
   };
 }
 
@@ -339,7 +308,7 @@ export class XClient {
     while (page < maxPages) {
       const url = new URL(`${X_API_BASE}/users/${encodeURIComponent(userId)}/tweets`);
       url.searchParams.set("max_results", String(maxResults));
-      url.searchParams.set("tweet.fields", "id,text,created_at,author_id,lang,attachments,entities,referenced_tweets");
+      url.searchParams.set("tweet.fields", "id,text,created_at,author_id,attachments,referenced_tweets");
       url.searchParams.set(
         "expansions",
         "author_id,attachments.media_keys,referenced_tweets.id,referenced_tweets.id.author_id",

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -167,11 +167,9 @@ const makePost = (id: string, createdAt: string, extra: Partial<XPost> = {}): XP
   sourcePostId: id,
   text: `post ${id}`,
   createdAt,
-  lang: "en",
   author: sampleUser,
   repostedBy: null,
   media: [],
-  urls: [],
   ...extra,
 });
 
@@ -200,27 +198,6 @@ describe("buildPostEntry", () => {
     expect(entry.reposted_by).toBeNull();
   });
 
-  it("maps post entities.urls to post urls with snake_case keys", () => {
-    const post = makePost("5", "2026-04-11T12:00:00.000Z", {
-      urls: [
-        {
-          url: "https://t.co/abc",
-          expandedUrl: "https://example.com/page",
-          displayUrl: "example.com/page",
-        },
-      ],
-    });
-    const entry = buildPostEntry(post);
-    expect(entry.urls).toEqual([
-      { url: "https://t.co/abc", expanded_url: "https://example.com/page", display_url: "example.com/page" },
-    ]);
-  });
-
-  it("returns an empty urls array when the post has no link entities", () => {
-    const entry = buildPostEntry(makePost("1", "2026-04-11T12:00:00.000Z"));
-    expect(entry.urls).toEqual([]);
-  });
-
   it("surfaces the original author in author and the reposter in reposted_by for reposts", () => {
     const originalAuthor: XUser = {
       id: "999",
@@ -233,11 +210,9 @@ describe("buildPostEntry", () => {
       sourcePostId: "1500", // original post id by sama
       text: "full original text",
       createdAt: "2026-04-11T12:00:00.000Z",
-      lang: "en",
       author: originalAuthor,
       repostedBy: sampleUser,
       media: [],
-      urls: [],
     };
     const entry = buildPostEntry(post);
     expect(entry.id).toBe("1700");

--- a/test/xfetch/xClient.test.ts
+++ b/test/xfetch/xClient.test.ts
@@ -172,7 +172,6 @@ describe("XClient.fetchUserPosts", () => {
     expect(expansions).toContain("referenced_tweets.id");
     expect(expansions).toContain("referenced_tweets.id.author_id");
     const tweetFields = url.searchParams.get("tweet.fields") ?? "";
-    expect(tweetFields).toContain("entities");
     expect(tweetFields).toContain("referenced_tweets");
     expect(url.searchParams.get("user.fields")).toContain("profile_image_url");
   });
@@ -194,7 +193,6 @@ describe("XClient.fetchUserPosts", () => {
             text: "hi",
             created_at: "2026-04-11T00:00:00.000Z",
             author_id: "1",
-            lang: "en",
             attachments: { media_keys: ["m1"] },
           },
         ],
@@ -218,70 +216,9 @@ describe("XClient.fetchUserPosts", () => {
         mediaKey: "m1",
       },
     ]);
-    expect(result.posts[0].lang).toBe("en");
     expect(result.posts[0].author.username).toBe("elonmusk");
     expect(result.posts[0].repostedBy).toBeNull();
     expect(result.posts[0].sourcePostId).toBe("100");
-  });
-
-  it("maps entities.urls to XPost.urls", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        data: [
-          {
-            id: "100",
-            text: "check this out https://t.co/abc",
-            created_at: "2026-04-11T00:00:00.000Z",
-            author_id: "1",
-            entities: {
-              urls: [
-                {
-                  url: "https://t.co/abc",
-                  expanded_url: "https://example.com/page",
-                  display_url: "example.com/page",
-                },
-                {
-                  url: "https://t.co/no-expand",
-                },
-              ],
-            },
-          },
-        ],
-        meta: { result_count: 1 },
-      }),
-    );
-    const client = new XClient("token");
-    const result = await client.fetchUserPosts("1");
-    expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error("unexpected error");
-    expect(result.posts[0].urls).toEqual([
-      {
-        url: "https://t.co/abc",
-        expandedUrl: "https://example.com/page",
-        displayUrl: "example.com/page",
-      },
-    ]);
-  });
-
-  it("returns an empty urls array when the post has no entities field", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        data: [
-          {
-            id: "100",
-            text: "no links",
-            created_at: "2026-04-11T00:00:00.000Z",
-            author_id: "1",
-          },
-        ],
-        meta: { result_count: 1 },
-      }),
-    );
-    const client = new XClient("token");
-    const result = await client.fetchUserPosts("1");
-    expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error("unexpected error");
-    expect(result.posts[0].urls).toEqual([]);
   });
 
   it("resolves reposts from includes and swaps the author with the original poster", async () => {
@@ -307,16 +244,6 @@ describe("XClient.fetchUserPosts", () => {
               text: "full original text from sama",
               created_at: "2026-04-10T09:00:00.000Z",
               author_id: "sama_id",
-              lang: "en",
-              entities: {
-                urls: [
-                  {
-                    url: "https://t.co/link",
-                    expanded_url: "https://example.com/page",
-                    display_url: "example.com/page",
-                  },
-                ],
-              },
               attachments: { media_keys: ["m9"] },
             },
           ],
@@ -336,11 +263,9 @@ describe("XClient.fetchUserPosts", () => {
     expect(post.sourcePostId).toBe("1500"); // original id for URL generation
     expect(post.text).toBe("full original text from sama");
     expect(post.createdAt).toBe("2026-04-11T12:00:00.000Z"); // repost time, not original
-    expect(post.lang).toBe("en");
     expect(post.author.username).toBe("sama");
     expect(post.repostedBy?.username).toBe("elonmusk");
     expect(post.media.map((m) => m.mediaKey)).toEqual(["m9"]);
-    expect(post.urls.map((u) => u.expandedUrl)).toEqual(["https://example.com/page"]);
   });
 
   it("falls back to the reposter as author when the referenced post is missing from includes", async () => {


### PR DESCRIPTION
## Summary
This PR removes the `lang` and `urls` fields from post data structures across the codebase, simplifying the data model by eliminating language metadata and URL entity mapping functionality.

## Key Changes
- **Removed fields from XPost interface**: Deleted `lang: string | null` and `urls: XUrlEntry[]` properties
- **Removed URL entity mapping**: Deleted `XUrlEntry` interface and `mapRawUrls()` function that parsed tweet entities
- **Simplified API requests**: Removed `lang` and `entities` from the `tweet.fields` parameter in X API calls
- **Updated data structures**: Removed corresponding fields from `PostEntry` interface and `UrlInfo` interface
- **Cleaned up type definitions**: Removed `RawUrlEntity` interface and `lang` field from `RawPost` interface
- **Updated post building logic**: Removed URL and language mapping from `buildXPostFromRaw()` and `buildPostEntry()` functions
- **Updated tests**: Removed all test cases and assertions related to language and URL entity handling

## Implementation Details
The changes maintain backward compatibility at the API level by simply not requesting or processing these fields. The removal is clean with no orphaned code or references remaining. All related test coverage for these features has been removed as well.

https://claude.ai/code/session_01GACJrApMeZppw8t7gh5TXK