### PR TITLE
Move mergeStateAfterRun and AccountRunResult to main.ts

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -1,6 +1,6 @@
 import { parseArgs as nodeParseArgs } from "node:util";
-import type { AccountRunResult, XfetchState } from "./state.js";
-import { getAccountState, getDefaultStatePath, loadState, mergeStateAfterRun, saveState } from "./state.js";
+import type { AccountState, XfetchState } from "./state.js";
+import { getAccountState, getDefaultStatePath, loadState, STATE_VERSION, saveState } from "./state.js";
 import type { FetchUserPostsOptions, XClientApi, XError, XPost, XUser } from "./xClient.js";
 import { XClient } from "./xClient.js";
 
@@ -175,6 +175,12 @@ export function buildRunOutput(
   };
 }
 
+export interface AccountRunResult {
+  username: string;
+  status: "ok" | "baseline_established" | "error";
+  newLastSeenId?: string | null;
+}
+
 interface ProcessedAccount {
   accountResult: AccountRunResult;
   posts: PostEntry[];
@@ -245,6 +251,29 @@ export async function processAccount(
     errorEntry: null,
     baselineEstablished: false,
   };
+}
+
+export function mergeStateAfterRun(
+  state: XfetchState,
+  results: readonly AccountRunResult[],
+  now: Date = new Date(),
+): XfetchState {
+  const nowIso = now.toISOString();
+  const accounts: Record<string, AccountState> = { ...state.accounts };
+
+  for (const result of results) {
+    if (result.status === "error") {
+      continue;
+    }
+    const key = result.username.toLowerCase();
+    const previous = accounts[key];
+    accounts[key] = {
+      lastSeenId: result.newLastSeenId ?? previous?.lastSeenId ?? null,
+      lastCheckedAt: nowIso,
+    };
+  }
+
+  return { version: STATE_VERSION, accounts };
 }
 
 export async function run(options: RunOptions): Promise<void> {

--- a/src/xfetch/state.ts
+++ b/src/xfetch/state.ts
@@ -18,12 +18,6 @@ export interface XfetchState {
   accounts: Record<string, AccountState>;
 }
 
-export interface AccountRunResult {
-  username: string;
-  status: "ok" | "baseline_established" | "error";
-  newLastSeenId?: string | null;
-}
-
 export function emptyState(): XfetchState {
   return { version: STATE_VERSION, accounts: {} };
 }
@@ -68,29 +62,6 @@ export async function saveState(state: XfetchState, path: string = getDefaultSta
   const tmp = `${absolute}.tmp`;
   await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
   await rename(tmp, absolute);
-}
-
-export function mergeStateAfterRun(
-  state: XfetchState,
-  results: readonly AccountRunResult[],
-  now: Date = new Date(),
-): XfetchState {
-  const nowIso = now.toISOString();
-  const accounts: Record<string, AccountState> = { ...state.accounts };
-
-  for (const result of results) {
-    if (result.status === "error") {
-      continue;
-    }
-    const key = result.username.toLowerCase();
-    const previous = accounts[key];
-    accounts[key] = {
-      lastSeenId: result.newLastSeenId ?? previous?.lastSeenId ?? null,
-      lastCheckedAt: nowIso,
-    };
-  }
-
-  return { version: STATE_VERSION, accounts };
 }
 
 export function getAccountState(state: XfetchState, username: string): AccountState | undefined {

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -1,14 +1,16 @@
 import { aroundEach, describe, expect, it } from "vitest";
-import type { PostEntry, RunOptions } from "@/xfetch/main.js";
+import type { AccountRunResult, PostEntry, RunOptions } from "@/xfetch/main.js";
 import {
   buildPostEntry,
   buildRunOutput,
   filterPostsByPattern,
+  mergeStateAfterRun,
   parseArgs,
   parseUsername,
   processAccount,
   sortPostsChronologically,
 } from "@/xfetch/main.js";
+import type { XfetchState } from "@/xfetch/state.js";
 import { emptyState, STATE_VERSION } from "@/xfetch/state.js";
 import type { FetchUserPostsOptions, XClientApi, XPost, XUser } from "@/xfetch/xClient.js";
 
@@ -451,5 +453,61 @@ describe("processAccount", () => {
     });
     expect(processed.posts.map((p) => p.text)).toEqual(["useful content"]);
     expect(processed.accountResult.newLastSeenId).toBe("200");
+  });
+});
+
+// ── mergeStateAfterRun ───────────────────────────────────────
+
+describe("mergeStateAfterRun", () => {
+  const NOW = new Date("2026-04-11T12:00:00.000Z");
+
+  it("updates lastSeenId for successful accounts", () => {
+    const state: XfetchState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    const results: AccountRunResult[] = [{ username: "elonmusk", status: "ok", newLastSeenId: "200" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "200",
+      lastCheckedAt: NOW.toISOString(),
+    });
+  });
+
+  it("keeps existing lastSeenId when error occurs", () => {
+    const state: XfetchState = {
+      version: STATE_VERSION,
+      accounts: {
+        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
+      },
+    };
+    const results: AccountRunResult[] = [{ username: "elonmusk", status: "error" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "100",
+      lastCheckedAt: "2026-04-01T00:00:00.000Z",
+    });
+  });
+
+  it("records baseline_established entries with their newLastSeenId", () => {
+    const state = emptyState();
+    const results: AccountRunResult[] = [
+      { username: "elonmusk", status: "baseline_established", newLastSeenId: "555" },
+    ];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toEqual({
+      lastSeenId: "555",
+      lastCheckedAt: NOW.toISOString(),
+    });
+  });
+
+  it("stores account keys case-insensitively", () => {
+    const state = emptyState();
+    const results: AccountRunResult[] = [{ username: "ElonMusk", status: "ok", newLastSeenId: "1" }];
+    const next = mergeStateAfterRun(state, results, NOW);
+    expect(next.accounts.elonmusk).toBeDefined();
+    expect(next.accounts.ElonMusk).toBeUndefined();
   });
 });

--- a/test/xfetch/state.test.ts
+++ b/test/xfetch/state.test.ts
@@ -2,13 +2,12 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, aroundEach, beforeEach, describe, expect, it } from "vitest";
-import type { AccountRunResult, XfetchState } from "@/xfetch/state.js";
+import type { XfetchState } from "@/xfetch/state.js";
 import {
   emptyState,
   getAccountState,
   getDefaultStatePath,
   loadState,
-  mergeStateAfterRun,
   resolveStatePath,
   STATE_VERSION,
   saveState,
@@ -122,60 +121,6 @@ describe("saveState", () => {
 
     const loaded = await loadState(path);
     expect(loaded).toEqual(state);
-  });
-});
-
-describe("mergeStateAfterRun", () => {
-  const NOW = new Date("2026-04-11T12:00:00.000Z");
-
-  it("updates lastSeenId for successful accounts", () => {
-    const state: XfetchState = {
-      version: STATE_VERSION,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
-      },
-    };
-    const results: AccountRunResult[] = [{ username: "elonmusk", status: "ok", newLastSeenId: "200" }];
-    const next = mergeStateAfterRun(state, results, NOW);
-    expect(next.accounts.elonmusk).toEqual({
-      lastSeenId: "200",
-      lastCheckedAt: NOW.toISOString(),
-    });
-  });
-
-  it("keeps existing lastSeenId when error occurs", () => {
-    const state: XfetchState = {
-      version: STATE_VERSION,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-01T00:00:00.000Z" },
-      },
-    };
-    const results: AccountRunResult[] = [{ username: "elonmusk", status: "error" }];
-    const next = mergeStateAfterRun(state, results, NOW);
-    expect(next.accounts.elonmusk).toEqual({
-      lastSeenId: "100",
-      lastCheckedAt: "2026-04-01T00:00:00.000Z",
-    });
-  });
-
-  it("records baseline_established entries with their newLastSeenId", () => {
-    const state = emptyState();
-    const results: AccountRunResult[] = [
-      { username: "elonmusk", status: "baseline_established", newLastSeenId: "555" },
-    ];
-    const next = mergeStateAfterRun(state, results, NOW);
-    expect(next.accounts.elonmusk).toEqual({
-      lastSeenId: "555",
-      lastCheckedAt: NOW.toISOString(),
-    });
-  });
-
-  it("stores account keys case-insensitively", () => {
-    const state = emptyState();
-    const results: AccountRunResult[] = [{ username: "ElonMusk", status: "ok", newLastSeenId: "1" }];
-    const next = mergeStateAfterRun(state, results, NOW);
-    expect(next.accounts.elonmusk).toBeDefined();
-    expect(next.accounts.ElonMusk).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
Refactored code organization by moving `mergeStateAfterRun` function and `AccountRunResult` interface from the state module to main.ts, along with updating related imports.

## Key Changes
- Moved `AccountRunResult` interface definition from state.js to main.ts and exported it
- Moved `mergeStateAfterRun` function implementation from state.js to main.ts and exported it
- Updated imports in main.ts to remove `mergeStateAfterRun` from state module imports
- Changed import of `AccountRunResult` type to `AccountState` type from state module
- Added `STATE_VERSION` to the imports from state module (used by the relocated function)

## Implementation Details
The `mergeStateAfterRun` function logic remains unchanged - it still merges account run results into the application state by updating `lastSeenId` and `lastCheckedAt` for each account. This appears to be a code organization improvement to keep run-related logic closer to where it's used in the main module.

https://claude.ai/code/session_01EAbtm1wwNjczAJGANaQ8da