### PR TITLE
Remove unused fields from API response interfaces

### DIFF
--- a/src/xfetch/xClient.ts
+++ b/src/xfetch/xClient.ts
@@ -95,17 +95,12 @@ interface RawPostsResponse {
     users?: RawUser[];
   };
   meta?: {
-    result_count?: number;
     next_token?: string;
-    newest_id?: string;
-    oldest_id?: string;
   };
-  errors?: unknown;
 }
 
 interface RawUsersResponse {
   data?: RawUser[];
-  errors?: Array<{ parameter?: string; value?: string; detail?: string }>;
 }
 
 export function normalizeProfileImageUrl(url: string | undefined | null): string | null {


### PR DESCRIPTION
## Summary
Cleaned up the TypeScript interfaces for API responses by removing unused fields that are no longer needed or referenced in the codebase.

## Key Changes
- **RawPostsResponse**: Removed unused `meta` fields (`result_count`, `newest_id`, `oldest_id`) and the `errors` field
- **RawUsersResponse**: Removed unused `errors` field from the response interface

## Details
These fields were defined in the response type interfaces but were not being utilized anywhere in the codebase. Removing them reduces unnecessary type definitions and makes the interfaces more maintainable by only including fields that are actually consumed by the application.

https://claude.ai/code/session_01HpPuBwBTe4wuYk1K2H9unK