### PR TITLE
Extract error mapping logic into toErrorEntry function

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -137,6 +137,15 @@ function toAuthorInfo(user: XUser): AuthorInfo {
   };
 }
 
+export function toErrorEntry(username: string, error: XError): ErrorEntry {
+  return {
+    username,
+    code: error.code,
+    message: error.message,
+    ...(error.resetAt ? { reset_at: error.resetAt } : {}),
+  };
+}
+
 export function filterPostsByPattern(posts: PostEntry[], patterns: RegExp[], invertMatch: boolean): PostEntry[] {
   if (patterns.length === 0) return posts;
   return posts.filter((post) => {
@@ -208,12 +217,7 @@ export async function processAccount(
     return {
       accountResult: { username, status: "error" },
       posts: [],
-      errorEntry: {
-        username,
-        code: result.error.code,
-        message: result.error.message,
-        ...(result.error.resetAt ? { reset_at: result.error.resetAt } : {}),
-      },
+      errorEntry: toErrorEntry(username, result.error),
       baselineEstablished: false,
     };
   }
@@ -292,13 +296,8 @@ export async function run(options: RunOptions): Promise<void> {
 
   if (!lookup.ok) {
     // Global failure during user lookup — no per-account processing possible.
-    for (const username of options.usernames) {
-      errors.push({
-        username,
-        code: lookup.error.code,
-        message: lookup.error.message,
-        ...(lookup.error.resetAt ? { reset_at: lookup.error.resetAt } : {}),
-      });
+    for (const u of options.usernames) {
+      errors.push(toErrorEntry(u, lookup.error));
     }
     const output = buildRunOutput(now, options.usernames.length, 0, posts, errors);
     console.log(JSON.stringify(output));

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -8,6 +8,7 @@ import {
   parseArgs,
   parseUsername,
   processAccount,
+  toErrorEntry,
 } from "@/xfetch/main.js";
 import type { XfetchState } from "@/xfetch/state.js";
 import { emptyState, STATE_VERSION } from "@/xfetch/state.js";
@@ -263,6 +264,29 @@ describe("buildRunOutput", () => {
       baseline_established: 1,
       total_posts: 2,
       errors: 1,
+    });
+  });
+});
+
+// ── toErrorEntry ─────────────────────────────────────────────
+
+describe("toErrorEntry", () => {
+  it("maps XError fields to ErrorEntry", () => {
+    const entry = toErrorEntry("elonmusk", { code: "rate_limited", message: "429", resetAt: null });
+    expect(entry).toEqual({ username: "elonmusk", code: "rate_limited", message: "429" });
+  });
+
+  it("includes reset_at when resetAt is present", () => {
+    const entry = toErrorEntry("elonmusk", {
+      code: "rate_limited",
+      message: "429",
+      resetAt: "2026-04-11T13:00:00.000Z",
+    });
+    expect(entry).toEqual({
+      username: "elonmusk",
+      code: "rate_limited",
+      message: "429",
+      reset_at: "2026-04-11T13:00:00.000Z",
     });
   });
 });


### PR DESCRIPTION
## Summary
Refactored error handling code to eliminate duplication by extracting the error-to-entry mapping logic into a reusable `toErrorEntry` function.

## Key Changes
- **New function**: Added `toErrorEntry(username: string, error: XError): ErrorEntry` to centralize the conversion of `XError` objects to `ErrorEntry` format, including conditional `reset_at` field mapping
- **Reduced duplication**: Replaced two instances of inline error mapping code in `processAccount` and `run` functions with calls to the new utility function
- **Improved testability**: Added comprehensive unit tests for `toErrorEntry` covering both cases (with and without `resetAt` field)

## Implementation Details
The `toErrorEntry` function uses object spread syntax to conditionally include the `reset_at` field only when `error.resetAt` is present, maintaining the existing behavior while centralizing the logic. This eliminates the need to repeat this pattern in multiple locations throughout the codebase.

https://claude.ai/code/session_01HjGNRM4ux1YFuP7V8QyCSt