### PR TITLE
Refactor error handling to use exceptions instead of process.exit

### DIFF
--- a/src/xfetch/cli.ts
+++ b/src/xfetch/cli.ts
@@ -1,11 +1,21 @@
 import "dotenv/config";
+import type { RunOptions } from "./main.js";
 import { parseArgs, run } from "./main.js";
 
-run(parseArgs(process.argv))
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((error) => {
-    console.error(error);
+async function main(): Promise<void> {
+  let options: RunOptions;
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
-  });
+  }
+
+  const code = await run(options);
+  process.exit(code);
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -89,8 +89,7 @@ export function parseArgs(argv: string[]): RunOptions {
     try {
       patterns.push(new RegExp(p));
     } catch {
-      console.error(`Error: invalid regexp pattern: ${p}`);
-      process.exit(1);
+      throw new Error(`invalid regexp pattern: ${p}`);
     }
   }
 
@@ -107,8 +106,7 @@ export function parseArgs(argv: string[]): RunOptions {
 export function requireBearerToken(): string {
   const token = process.env.X_BEARER_TOKEN;
   if (!token) {
-    console.error("Error: X_BEARER_TOKEN environment variable is not set");
-    process.exit(1);
+    throw new Error("X_BEARER_TOKEN environment variable is not set");
   }
   return token;
 }
@@ -273,14 +271,14 @@ export function mergeStateAfterRun(
   return { version: STATE_VERSION, accounts };
 }
 
-export async function run(options: RunOptions): Promise<void> {
+export async function run(options: RunOptions): Promise<number> {
   if (options.usernames.length === 0) {
     console.error(
       JSON.stringify({
         error: "No usernames specified. Usage: xfetch [options] <username1> [username2 ...]",
       }),
     );
-    process.exit(1);
+    return 1;
   }
 
   const bearerToken = requireBearerToken();
@@ -301,7 +299,7 @@ export async function run(options: RunOptions): Promise<void> {
     }
     const output = buildRunOutput(now, options.usernames.length, 0, posts, errors);
     console.log(JSON.stringify(output));
-    process.exit(1);
+    return 1;
   }
 
   const { found } = lookup;
@@ -352,7 +350,5 @@ export async function run(options: RunOptions): Promise<void> {
   console.log(JSON.stringify(output));
 
   const anySuccess = accountResults.some((r) => r.status !== "error");
-  if (!anySuccess) {
-    process.exit(1);
-  }
+  return anySuccess ? 0 : 1;
 }

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -8,6 +8,7 @@ import {
   parseArgs,
   parseUsername,
   processAccount,
+  requireBearerToken,
   toErrorEntry,
 } from "@/xfetch/main.js";
 import type { XfetchState } from "@/xfetch/state.js";
@@ -132,6 +133,10 @@ describe("parseArgs", () => {
   it("extracts username from https://x.com/foo URL", () => {
     const options = parseArgs(makeArgv("https://x.com/elonmusk"));
     expect(options.usernames).toEqual(["elonmusk"]);
+  });
+
+  it("throws an Error for an invalid regexp pattern", () => {
+    expect(() => parseArgs(makeArgv("-e", "[invalid", "elon"))).toThrow("invalid regexp pattern: [invalid");
   });
 });
 
@@ -526,5 +531,26 @@ describe("mergeStateAfterRun", () => {
     const next = mergeStateAfterRun(state, results, NOW);
     expect(next.accounts.elonmusk).toBeDefined();
     expect(next.accounts.ElonMusk).toBeUndefined();
+  });
+});
+
+// ── requireBearerToken ───────────────────────────────────────
+
+describe("requireBearerToken", () => {
+  aroundEach(async (test) => {
+    const saved = process.env.X_BEARER_TOKEN;
+    await test();
+    if (saved === undefined) delete process.env.X_BEARER_TOKEN;
+    else process.env.X_BEARER_TOKEN = saved;
+  });
+
+  it("returns the token when X_BEARER_TOKEN is set", () => {
+    process.env.X_BEARER_TOKEN = "mytoken";
+    expect(requireBearerToken()).toBe("mytoken");
+  });
+
+  it("throws an Error when X_BEARER_TOKEN is not set", () => {
+    delete process.env.X_BEARER_TOKEN;
+    expect(() => requireBearerToken()).toThrow("X_BEARER_TOKEN environment variable is not set");
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors the error handling strategy in the xfetch CLI to throw exceptions instead of directly calling `process.exit()`. This makes the code more testable and follows better practices for library functions.

## Key Changes
- **Error handling in `parseArgs()`**: Changed invalid regexp pattern errors to throw an `Error` instead of logging and exiting
- **Error handling in `requireBearerToken()`**: Changed missing token errors to throw an `Error` instead of logging and exiting
- **Return type of `run()`**: Changed from `Promise<void>` to `Promise<number>` to return exit codes (0 for success, 1 for failure) instead of calling `process.exit()`
- **CLI entry point (`cli.ts`)**: Updated to handle exceptions from `parseArgs()` and use the exit code returned by `run()`
- **Test coverage**: Added comprehensive tests for the new error-throwing behavior in `requireBearerToken()` and `parseArgs()`

## Implementation Details
- The CLI's `main()` function now wraps `parseArgs()` in a try-catch block to handle validation errors gracefully
- Exit codes are now determined by the return value of `run()` rather than internal `process.exit()` calls
- This change makes the core functions (`parseArgs`, `requireBearerToken`, `run`) more suitable for use as a library, as they no longer have side effects that terminate the process
- Environment variable cleanup is properly handled in tests using `aroundEach` hook

https://claude.ai/code/session_01J5iNfSG7QhU8CVzn5ftwPY