### PR TITLE
Refactor processAccount to accept AccountState directly

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -181,12 +181,11 @@ interface ProcessedAccount {
 export async function processAccount(
   username: string,
   userId: string,
-  state: XfetchState,
+  state: AccountState | undefined,
   client: XClientApi,
   options: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch">,
 ): Promise<ProcessedAccount> {
-  const previous = getAccountState(state, username);
-  const isFirstRun = !previous || previous.lastSeenId === null;
+  const isFirstRun = !state || state.lastSeenId === null;
 
   const fetchOptions: FetchUserPostsOptions = {
     includeReposts: options.includeReposts,
@@ -199,7 +198,7 @@ export async function processAccount(
     fetchOptions.maxResults = 5;
     fetchOptions.maxPages = 1;
   } else {
-    fetchOptions.sinceId = previous?.lastSeenId ?? null;
+    fetchOptions.sinceId = state?.lastSeenId ?? null;
   }
 
   const result = await client.fetchUserPosts(userId, fetchOptions);
@@ -232,7 +231,7 @@ export async function processAccount(
   }
 
   // sort: true returns posts oldest-first; the last element is the newest.
-  const newestId = posts.at(-1)?.id ?? previous?.lastSeenId ?? null;
+  const newestId = posts.at(-1)?.id ?? state?.lastSeenId ?? null;
 
   return {
     accountResult: { username, status: "ok", newLastSeenId: newestId },
@@ -320,7 +319,7 @@ export async function run(options: RunOptions): Promise<void> {
     .filter((t): t is { username: string; userId: string } => t !== null);
 
   const settled = await Promise.allSettled(
-    tasks.map((t) => processAccount(t.username, t.userId, state, client, options)),
+    tasks.map((t) => processAccount(t.username, t.userId, getAccountState(state, t.username), client, options)),
   );
 
   for (let i = 0; i < settled.length; i += 1) {

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -293,8 +293,7 @@ describe("processAccount", () => {
       capturedOpts = opts;
       return [makePost("999", "2026-04-11T12:00:00.000Z")];
     });
-    const state = emptyState();
-    const processed = await processAccount("elonmusk", "123", state, client, baseOptions);
+    const processed = await processAccount("elonmusk", "123", undefined, client, baseOptions);
     expect(processed.accountResult.status).toBe("baseline_established");
     expect(processed.accountResult.newLastSeenId).toBe("999");
     expect(processed.posts).toEqual([]);
@@ -313,12 +312,7 @@ describe("processAccount", () => {
       // Simulate sort: true — oldest first.
       return [makePost("199", "2026-04-11T11:00:00.000Z"), makePost("200", "2026-04-11T12:00:00.000Z")];
     });
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, baseOptions);
     expect(capturedOpts?.sinceId).toBe("100");
     // Subsequent runs should use the xClient defaults (page size / max pages).
@@ -335,12 +329,7 @@ describe("processAccount", () => {
 
   it("preserves cached lastSeenId on a subsequent run with no new posts", async () => {
     const client = makeClient(async () => []);
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, baseOptions);
     expect(processed.accountResult).toEqual({
       username: "elonmusk",
@@ -360,12 +349,7 @@ describe("processAccount", () => {
         error: { code: "rate_limited", message: "429", resetAt: "2026-04-11T13:00:00.000Z" },
       }),
     };
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, baseOptions);
     expect(processed.accountResult.status).toBe("error");
     expect(processed.errorEntry).toEqual({
@@ -379,7 +363,7 @@ describe("processAccount", () => {
 
   it("returns empty baseline when account has zero posts", async () => {
     const client = makeClient(async () => []);
-    const processed = await processAccount("elonmusk", "123", emptyState(), client, baseOptions);
+    const processed = await processAccount("elonmusk", "123", undefined, client, baseOptions);
     expect(processed.accountResult).toEqual({
       username: "elonmusk",
       status: "baseline_established",
@@ -392,12 +376,7 @@ describe("processAccount", () => {
       makePost("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
       makePost("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
     ]);
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, {
       ...baseOptions,
       patterns: [/hello/],
@@ -411,12 +390,7 @@ describe("processAccount", () => {
       makePost("200", "2026-04-11T12:00:00.000Z", { text: "hello world" }),
       makePost("199", "2026-04-11T11:00:00.000Z", { text: "foo bar" }),
     ]);
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, {
       ...baseOptions,
       patterns: [/hello/],
@@ -433,12 +407,7 @@ describe("processAccount", () => {
       makePost("199", "2026-04-11T11:00:00.000Z", { text: "useful content" }),
       makePost("200", "2026-04-11T12:00:00.000Z", { text: "spam content" }),
     ]);
-    const state = {
-      version: STATE_VERSION as 1,
-      accounts: {
-        elonmusk: { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" },
-      },
-    };
+    const state = { lastSeenId: "100", lastCheckedAt: "2026-04-10T00:00:00.000Z" };
     const processed = await processAccount("elonmusk", "123", state, client, {
       ...baseOptions,
       patterns: [/spam/],


### PR DESCRIPTION
## Summary
Refactored the `processAccount` function to accept an `AccountState | undefined` parameter directly instead of the full `XfetchState` object, moving the responsibility of extracting the account state to the caller.

## Key Changes
- **Function signature update**: Changed `processAccount` parameter from `state: XfetchState` to `previous: AccountState | undefined`
- **Logic relocation**: Moved `getAccountState(state, username)` call from inside `processAccount` to the `run` function where it's invoked
- **Test updates**: Simplified test setup by passing `undefined` or individual `AccountState` objects directly instead of constructing full state objects with `STATE_VERSION` and nested account structures

## Implementation Details
- The function now receives the pre-extracted account state, making it more focused and easier to test
- Tests are cleaner and more readable, reducing boilerplate by eliminating the need to construct full `XfetchState` objects for each test case
- The change maintains the same functionality while improving separation of concerns—`processAccount` no longer needs to know about the overall state structure

https://claude.ai/code/session_01NzHmdi2g56Mpy1eHSGD6Mt