### PR TITLE
Add --inline-media flag to append media URLs to post text

### DIFF
--- a/src/xfetch/main.ts
+++ b/src/xfetch/main.ts
@@ -11,6 +11,7 @@ export interface RunOptions {
   includeReplies: boolean;
   patterns: RegExp[];
   invertMatch: boolean;
+  inlineMedia: boolean;
 }
 
 export interface AuthorInfo {
@@ -80,6 +81,7 @@ export function parseArgs(argv: string[]): RunOptions {
       "exclude-replies": { type: "boolean" },
       regexp: { type: "string", multiple: true, short: "e" },
       "invert-match": { type: "boolean", short: "v" },
+      "inline-media": { type: "boolean" },
     },
     allowPositionals: true,
   });
@@ -101,6 +103,7 @@ export function parseArgs(argv: string[]): RunOptions {
     includeReplies: values["exclude-replies"] ? false : (values["include-replies"] ?? false),
     patterns,
     invertMatch: values["invert-match"] ?? false,
+    inlineMedia: values["inline-media"] ?? false,
   };
 }
 
@@ -113,11 +116,18 @@ export function requireBearerToken(): string {
   return token;
 }
 
-export function buildPostEntry(post: XPost): PostEntry {
+export function buildPostEntry(post: XPost, options: { inlineMedia?: boolean } = {}): PostEntry {
+  let text = post.text;
+  if (options.inlineMedia && post.media.length > 0) {
+    const urls = post.media.map((m) => m.url ?? m.previewImageUrl).filter((url): url is string => url !== null);
+    if (urls.length > 0) {
+      text = `${text}\n${urls.join("\n")}`;
+    }
+  }
   return {
     id: post.id,
     url: `https://x.com/${post.author.username}/status/${post.id}`,
-    text: post.text,
+    text,
     created_at: post.createdAt,
     media: post.media.map((m) => ({
       type: m.type,
@@ -183,7 +193,7 @@ export async function processAccount(
   userId: string,
   state: XfetchState,
   client: XClientApi,
-  options: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch">,
+  options: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch" | "inlineMedia">,
 ): Promise<ProcessedAccount> {
   const previous = getAccountState(state, username);
   const isFirstRun = !previous || previous.lastSeenId === null;
@@ -237,7 +247,7 @@ export async function processAccount(
   return {
     accountResult: { username, status: "ok", newLastSeenId: newestId },
     posts: filterPostsByPattern(
-      posts.map((post) => buildPostEntry(post)),
+      posts.map((post) => buildPostEntry(post, { inlineMedia: options.inlineMedia })),
       options.patterns,
       options.invertMatch,
     ),

--- a/test/xfetch/main.test.ts
+++ b/test/xfetch/main.test.ts
@@ -39,6 +39,7 @@ describe("parseArgs", () => {
       includeReplies: false,
       patterns: [],
       invertMatch: false,
+      inlineMedia: false,
     });
   });
 
@@ -51,6 +52,7 @@ describe("parseArgs", () => {
       includeReplies: true,
       patterns: [],
       invertMatch: false,
+      inlineMedia: false,
     });
   });
 
@@ -63,6 +65,7 @@ describe("parseArgs", () => {
       includeReplies: false,
       patterns: [],
       invertMatch: false,
+      inlineMedia: false,
     });
   });
 
@@ -121,6 +124,11 @@ describe("parseArgs", () => {
   it("supports regexp special characters in -e patterns", () => {
     const options = parseArgs(makeArgv("-e", "^hello\\s+world$", "elon"));
     expect(options.patterns[0]).toEqual(/^hello\s+world$/);
+  });
+
+  it("parses --inline-media flag", () => {
+    const options = parseArgs(makeArgv("--inline-media", "elon"));
+    expect(options.inlineMedia).toBe(true);
   });
 
   it("strips a leading @ from usernames", () => {
@@ -190,6 +198,56 @@ describe("buildPostEntry", () => {
       profile_image_url: "https://pbs.twimg.com/profile_images/1/e_400x400.jpg",
     });
     expect(entry.media).toEqual([{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", preview_image_url: null }]);
+  });
+
+  it("does not modify text when inlineMedia is false (default)", () => {
+    const post = makePost("1", "2026-04-11T12:00:00.000Z", {
+      text: "hello",
+      media: [{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", previewImageUrl: null, mediaKey: "k1" }],
+    });
+    expect(buildPostEntry(post).text).toBe("hello");
+  });
+
+  it("appends photo url to text when inlineMedia is true", () => {
+    const post = makePost("1", "2026-04-11T12:00:00.000Z", {
+      text: "hello",
+      media: [{ type: "photo", url: "https://pbs.twimg.com/media/a.jpg", previewImageUrl: null, mediaKey: "k1" }],
+    });
+    expect(buildPostEntry(post, { inlineMedia: true }).text).toBe("hello\nhttps://pbs.twimg.com/media/a.jpg");
+  });
+
+  it("appends previewImageUrl when url is null (video/gif)", () => {
+    const post = makePost("2", "2026-04-11T12:00:00.000Z", {
+      text: "watch this",
+      media: [{ type: "video", url: null, previewImageUrl: "https://pbs.twimg.com/media/thumb.jpg", mediaKey: "k2" }],
+    });
+    expect(buildPostEntry(post, { inlineMedia: true }).text).toBe("watch this\nhttps://pbs.twimg.com/media/thumb.jpg");
+  });
+
+  it("appends multiple media urls separated by newlines", () => {
+    const post = makePost("3", "2026-04-11T12:00:00.000Z", {
+      text: "pics",
+      media: [
+        { type: "photo", url: "https://pbs.twimg.com/media/a.jpg", previewImageUrl: null, mediaKey: "k1" },
+        { type: "photo", url: "https://pbs.twimg.com/media/b.jpg", previewImageUrl: null, mediaKey: "k2" },
+      ],
+    });
+    expect(buildPostEntry(post, { inlineMedia: true }).text).toBe(
+      "pics\nhttps://pbs.twimg.com/media/a.jpg\nhttps://pbs.twimg.com/media/b.jpg",
+    );
+  });
+
+  it("does not append anything when all media urls are null", () => {
+    const post = makePost("4", "2026-04-11T12:00:00.000Z", {
+      text: "no urls",
+      media: [{ type: "video", url: null, previewImageUrl: null, mediaKey: "k1" }],
+    });
+    expect(buildPostEntry(post, { inlineMedia: true }).text).toBe("no urls");
+  });
+
+  it("does not modify text when there is no media", () => {
+    const post = makePost("5", "2026-04-11T12:00:00.000Z", { text: "plain text", media: [] });
+    expect(buildPostEntry(post, { inlineMedia: true }).text).toBe("plain text");
   });
 });
 
@@ -279,12 +337,14 @@ function makeClient(fetchImpl: (userId: string, opts?: FetchUserPostsOptions) =>
   };
 }
 
-const baseOptions: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch"> = {
-  includeReposts: true,
-  includeReplies: false,
-  patterns: [],
-  invertMatch: false,
-};
+const baseOptions: Pick<RunOptions, "includeReposts" | "includeReplies" | "patterns" | "invertMatch" | "inlineMedia"> =
+  {
+    includeReposts: true,
+    includeReplies: false,
+    patterns: [],
+    invertMatch: false,
+    inlineMedia: false,
+  };
 
 describe("processAccount", () => {
   it("returns baseline_established on first run without producing posts", async () => {


### PR DESCRIPTION
## Summary
This PR adds a new `--inline-media` command-line flag that appends media URLs directly to post text when enabled. This allows users to include media links in the output without relying on separate media metadata.

## Key Changes
- Added `inlineMedia: boolean` field to `RunOptions` interface
- Implemented `--inline-media` CLI flag parsing in `parseArgs()`
- Enhanced `buildPostEntry()` to append media URLs to post text when the flag is enabled:
  - Appends photo URLs directly from the `url` field
  - Falls back to `previewImageUrl` for videos/GIFs when `url` is null
  - Joins multiple media URLs with newlines
  - Skips appending if all media URLs are null or no media exists
- Updated `processAccount()` to pass the `inlineMedia` option through to `buildPostEntry()`
- Added comprehensive test coverage for the new functionality

## Implementation Details
- The media URL appending logic filters out null values and only appends if at least one valid URL exists
- The feature is opt-in (defaults to `false`) to maintain backward compatibility
- Media URLs are appended to the post text with a newline separator

https://claude.ai/code/session_01DrEBQaWSBMPUhUBwjSGMam