### PR TITLE
Add trafficnews article scraper with state management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ GITHUB_TOKEN=your_token_here
 GHOME_IP=192.168.1.100
 X_BEARER_TOKEN=your_bearer_token_here
 XFETCH_STATE_FILE=/path/to/xfetch_state.json
+TRAFFICNEWS_STATE_FILE=/path/to/trafficnews_state.json

--- a/src/trafficnews/cli.ts
+++ b/src/trafficnews/cli.ts
@@ -1,0 +1,21 @@
+import "dotenv/config";
+import type { RunOptions } from "./main.js";
+import { parseArgs, run } from "./main.js";
+
+async function main(): Promise<void> {
+  let options: RunOptions;
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  const code = await run(options);
+  process.exit(code);
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/trafficnews/main.ts
+++ b/src/trafficnews/main.ts
@@ -1,0 +1,117 @@
+import { parseArgs as nodeParseArgs } from "node:util";
+import { getDefaultStatePath, loadState, STATE_VERSION, saveState } from "./state.js";
+
+const TARGET_URL = "https://trafficnews.jp/category/road/page/1";
+export const MAX_SEEN_URLS = 50;
+
+export interface RunOptions {
+  statePath: string;
+}
+
+export interface ArticleEntry {
+  title: string;
+  url: string;
+}
+
+export interface RunOutput {
+  checked_at: string;
+  articles: ArticleEntry[];
+}
+
+export function parseArgs(argv: string[]): RunOptions {
+  const { values } = nodeParseArgs({
+    args: argv.slice(2),
+    options: {
+      state: { type: "string" },
+    },
+    allowPositionals: false,
+  });
+
+  return {
+    statePath: values.state ?? process.env.TRAFFICNEWS_STATE_FILE ?? getDefaultStatePath(),
+  };
+}
+
+export function extractArticles(html: string): ArticleEntry[] {
+  const seen = new Set<string>();
+  const articles: ArticleEntry[] = [];
+
+  // Match <a href="https://trafficnews.jp/post/NNNNN">...</a> inside heading-like contexts.
+  // Two passes: first look for headings containing links, then fall back to any post links.
+  const headingPattern =
+    /<h[1-6][^>]*>[\s\S]*?<a[^>]+href="(https:\/\/trafficnews\.jp\/post\/[^"]+)"[^>]*>([\s\S]*?)<\/a>[\s\S]*?<\/h[1-6]>/gi;
+  for (const match of html.matchAll(headingPattern)) {
+    const url = match[1];
+    const rawTitle = match[2]
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (url && rawTitle && !seen.has(url)) {
+      seen.add(url);
+      articles.push({ title: rawTitle, url });
+    }
+  }
+
+  // Fallback: any post links with non-empty anchor text not already captured
+  if (articles.length === 0) {
+    const linkPattern = /<a[^>]+href="(https:\/\/trafficnews\.jp\/post\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+    for (const match of html.matchAll(linkPattern)) {
+      const url = match[1];
+      const rawTitle = match[2]
+        .replace(/<[^>]+>/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (url && rawTitle && !seen.has(url)) {
+        seen.add(url);
+        articles.push({ title: rawTitle, url });
+      }
+    }
+  }
+
+  return articles;
+}
+
+export async function fetchArticles(url: string = TARGET_URL): Promise<ArticleEntry[]> {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (compatible; trafficnews-checker/1.0)",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${url}`);
+  }
+  const html = await response.text();
+  return extractArticles(html);
+}
+
+export function filterNewArticles(articles: ArticleEntry[], seenUrls: ReadonlySet<string>): ArticleEntry[] {
+  return articles.filter((a) => !seenUrls.has(a.url));
+}
+
+export function rotateSeenUrls(urls: string[], max: number = MAX_SEEN_URLS): string[] {
+  return urls.length > max ? urls.slice(-max) : urls;
+}
+
+export async function run(options: RunOptions): Promise<number> {
+  const state = await loadState(options.statePath);
+  const seenUrls = new Set(state.seenUrls);
+
+  const allArticles = await fetchArticles();
+  const newArticles = filterNewArticles(allArticles, seenUrls);
+
+  const output: RunOutput = {
+    checked_at: new Date().toISOString(),
+    articles: newArticles,
+  };
+  console.log(JSON.stringify(output, null, 2));
+
+  const nextSeenUrls = [...state.seenUrls];
+  for (const article of allArticles) {
+    if (!seenUrls.has(article.url)) {
+      nextSeenUrls.push(article.url);
+    }
+  }
+  await saveState({ version: STATE_VERSION, seenUrls: rotateSeenUrls(nextSeenUrls) }, options.statePath);
+
+  return 0;
+}

--- a/src/trafficnews/state.ts
+++ b/src/trafficnews/state.ts
@@ -1,0 +1,70 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+export const STATE_VERSION = 1;
+
+export interface TrafficNewsState {
+  version: typeof STATE_VERSION;
+  seenUrls: string[];
+}
+
+export function getDefaultStatePath(): string {
+  const xdgStateHome = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+  return join(xdgStateHome, "trafficnews", "state.json");
+}
+
+export function emptyState(): TrafficNewsState {
+  return { version: STATE_VERSION, seenUrls: [] };
+}
+
+export function resolveStatePath(path: string): string {
+  return isAbsolute(path) ? path : resolve(process.cwd(), path);
+}
+
+export async function loadState(path: string = getDefaultStatePath()): Promise<TrafficNewsState> {
+  const absolute = resolveStatePath(path);
+  let raw: string;
+  try {
+    raw = await readFile(absolute, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return emptyState();
+    }
+    console.warn(`[trafficnews] failed to read state at ${absolute}: ${(error as Error).message}`);
+    return emptyState();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`[trafficnews] state file is not valid JSON, starting fresh: ${(error as Error).message}`);
+    return emptyState();
+  }
+
+  if (!isTrafficNewsState(parsed)) {
+    console.warn("[trafficnews] state file schema is invalid or version mismatch, starting fresh");
+    return emptyState();
+  }
+  return parsed;
+}
+
+export async function saveState(state: TrafficNewsState, path: string = getDefaultStatePath()): Promise<void> {
+  const absolute = resolveStatePath(path);
+  const dir = dirname(absolute);
+  await mkdir(dir, { recursive: true });
+
+  const tmp = `${absolute}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await rename(tmp, absolute);
+}
+
+function isTrafficNewsState(value: unknown): value is TrafficNewsState {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { version?: unknown; seenUrls?: unknown };
+  if (candidate.version !== STATE_VERSION) return false;
+  if (!Array.isArray(candidate.seenUrls)) return false;
+  if (!candidate.seenUrls.every((u) => typeof u === "string")) return false;
+  return true;
+}

--- a/test/trafficnews/main.test.ts
+++ b/test/trafficnews/main.test.ts
@@ -1,0 +1,165 @@
+import { aroundEach, describe, expect, it } from "vitest";
+import { extractArticles, filterNewArticles, MAX_SEEN_URLS, parseArgs, rotateSeenUrls } from "@/trafficnews/main.js";
+
+// ── parseArgs ────────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  const makeArgv = (...rest: string[]) => ["node", "cli.js", ...rest];
+
+  aroundEach(async (test) => {
+    const savedXdgStateHome = process.env.XDG_STATE_HOME;
+    const savedStateFile = process.env.TRAFFICNEWS_STATE_FILE;
+    process.env.XDG_STATE_HOME = "/xdg/state";
+    delete process.env.TRAFFICNEWS_STATE_FILE;
+    await test();
+    if (savedXdgStateHome === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdgStateHome;
+    if (savedStateFile === undefined) delete process.env.TRAFFICNEWS_STATE_FILE;
+    else process.env.TRAFFICNEWS_STATE_FILE = savedStateFile;
+  });
+
+  it("uses XDG default state path when no args given", () => {
+    const options = parseArgs(makeArgv());
+    expect(options.statePath).toBe("/xdg/state/trafficnews/state.json");
+  });
+
+  it("uses --state argument when provided", () => {
+    const options = parseArgs(makeArgv("--state", "/tmp/custom.json"));
+    expect(options.statePath).toBe("/tmp/custom.json");
+  });
+
+  it("uses TRAFFICNEWS_STATE_FILE env var when --state is not provided", () => {
+    process.env.TRAFFICNEWS_STATE_FILE = "/env/state.json";
+    const options = parseArgs(makeArgv());
+    expect(options.statePath).toBe("/env/state.json");
+  });
+
+  it("--state argument takes precedence over TRAFFICNEWS_STATE_FILE env var", () => {
+    process.env.TRAFFICNEWS_STATE_FILE = "/env/state.json";
+    const options = parseArgs(makeArgv("--state", "/arg/state.json"));
+    expect(options.statePath).toBe("/arg/state.json");
+  });
+});
+
+// ── extractArticles ───────────────────────────────────────────
+
+describe("extractArticles", () => {
+  it("extracts articles from heading-wrapped links", () => {
+    const html = `
+      <h2 class="entry-title">
+        <a href="https://trafficnews.jp/post/12345">道路工事のお知らせ</a>
+      </h2>
+      <h2 class="entry-title">
+        <a href="https://trafficnews.jp/post/67890">新しい高速道路が開通</a>
+      </h2>
+    `;
+    const articles = extractArticles(html);
+    expect(articles).toHaveLength(2);
+    expect(articles[0]).toEqual({ title: "道路工事のお知らせ", url: "https://trafficnews.jp/post/12345" });
+    expect(articles[1]).toEqual({ title: "新しい高速道路が開通", url: "https://trafficnews.jp/post/67890" });
+  });
+
+  it("deduplicates articles with the same URL", () => {
+    const html = `
+      <h2><a href="https://trafficnews.jp/post/12345">タイトル</a></h2>
+      <h2><a href="https://trafficnews.jp/post/12345">タイトル</a></h2>
+    `;
+    const articles = extractArticles(html);
+    expect(articles).toHaveLength(1);
+  });
+
+  it("falls back to plain post links when no heading-wrapped links found", () => {
+    const html = `
+      <div class="card">
+        <a href="https://trafficnews.jp/post/99999">記事タイトル</a>
+      </div>
+    `;
+    const articles = extractArticles(html);
+    expect(articles).toHaveLength(1);
+    expect(articles[0]).toEqual({ title: "記事タイトル", url: "https://trafficnews.jp/post/99999" });
+  });
+
+  it("ignores links that are not post URLs", () => {
+    const html = `
+      <h2><a href="https://trafficnews.jp/category/road">カテゴリ</a></h2>
+      <h2><a href="https://example.com/post/12345">外部リンク</a></h2>
+      <h2><a href="https://trafficnews.jp/post/11111">正しい記事</a></h2>
+    `;
+    const articles = extractArticles(html);
+    expect(articles).toHaveLength(1);
+    expect(articles[0].url).toBe("https://trafficnews.jp/post/11111");
+  });
+
+  it("strips inner HTML tags from title", () => {
+    const html = `
+      <h2><a href="https://trafficnews.jp/post/22222"><span>タグ付き</span>タイトル</a></h2>
+    `;
+    const articles = extractArticles(html);
+    expect(articles[0].title).toBe("タグ付きタイトル");
+  });
+
+  it("returns empty array for HTML with no post links", () => {
+    const html = "<div>No articles here</div>";
+    expect(extractArticles(html)).toEqual([]);
+  });
+});
+
+// ── filterNewArticles ─────────────────────────────────────────
+
+describe("filterNewArticles", () => {
+  it("returns all articles when seenUrls is empty", () => {
+    const articles = [
+      { title: "A", url: "https://trafficnews.jp/post/1" },
+      { title: "B", url: "https://trafficnews.jp/post/2" },
+    ];
+    expect(filterNewArticles(articles, new Set())).toEqual(articles);
+  });
+
+  it("excludes articles whose URLs are in seenUrls", () => {
+    const articles = [
+      { title: "A", url: "https://trafficnews.jp/post/1" },
+      { title: "B", url: "https://trafficnews.jp/post/2" },
+      { title: "C", url: "https://trafficnews.jp/post/3" },
+    ];
+    const seen = new Set(["https://trafficnews.jp/post/1", "https://trafficnews.jp/post/3"]);
+    const result = filterNewArticles(articles, seen);
+    expect(result).toHaveLength(1);
+    expect(result[0].url).toBe("https://trafficnews.jp/post/2");
+  });
+
+  it("returns empty array when all articles are already seen", () => {
+    const articles = [{ title: "A", url: "https://trafficnews.jp/post/1" }];
+    const seen = new Set(["https://trafficnews.jp/post/1"]);
+    expect(filterNewArticles(articles, seen)).toEqual([]);
+  });
+});
+
+// ── rotateSeenUrls ────────────────────────────────────────────
+
+describe("rotateSeenUrls", () => {
+  it("returns the array unchanged when under the limit", () => {
+    const urls = ["url1", "url2", "url3"];
+    expect(rotateSeenUrls(urls, 10)).toEqual(urls);
+  });
+
+  it("returns the array unchanged when exactly at the limit", () => {
+    const urls = ["url1", "url2", "url3"];
+    expect(rotateSeenUrls(urls, 3)).toEqual(urls);
+  });
+
+  it("trims oldest entries when over the limit", () => {
+    const urls = ["old1", "old2", "keep1", "keep2", "keep3"];
+    expect(rotateSeenUrls(urls, 3)).toEqual(["keep1", "keep2", "keep3"]);
+  });
+
+  it("uses MAX_SEEN_URLS as default limit", () => {
+    const urls = Array.from({ length: MAX_SEEN_URLS + 10 }, (_, i) => `url${i}`);
+    const result = rotateSeenUrls(urls);
+    expect(result).toHaveLength(MAX_SEEN_URLS);
+    expect(result[0]).toBe(`url10`);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(rotateSeenUrls([], 10)).toEqual([]);
+  });
+});

--- a/test/trafficnews/state.test.ts
+++ b/test/trafficnews/state.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, aroundEach, beforeEach, describe, expect, it } from "vitest";
+import type { TrafficNewsState } from "@/trafficnews/state.js";
+import {
+  emptyState,
+  getDefaultStatePath,
+  loadState,
+  resolveStatePath,
+  STATE_VERSION,
+  saveState,
+} from "@/trafficnews/state.js";
+
+describe("resolveStatePath", () => {
+  it("leaves absolute paths alone", () => {
+    expect(resolveStatePath("/tmp/custom.json")).toBe("/tmp/custom.json");
+  });
+
+  it("resolves relative paths against cwd", () => {
+    const resolved = resolveStatePath("./trafficnews_state.json");
+    expect(resolved.startsWith("/")).toBe(true);
+    expect(resolved.endsWith("trafficnews_state.json")).toBe(true);
+  });
+});
+
+describe("getDefaultStatePath", () => {
+  aroundEach(async (test) => {
+    const savedXdgStateHome = process.env.XDG_STATE_HOME;
+    await test();
+    if (savedXdgStateHome === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdgStateHome;
+  });
+
+  it("returns XDG_STATE_HOME-based path when XDG_STATE_HOME is set", () => {
+    process.env.XDG_STATE_HOME = "/custom/xdg";
+    expect(getDefaultStatePath()).toBe("/custom/xdg/trafficnews/state.json");
+  });
+
+  it("falls back to ~/.local/state when XDG_STATE_HOME is not set", () => {
+    delete process.env.XDG_STATE_HOME;
+    expect(getDefaultStatePath()).toMatch(/\/\.local\/state\/trafficnews\/state\.json$/);
+  });
+});
+
+describe("loadState", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "trafficnews-state-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty state when file is missing", async () => {
+    const state = await loadState(join(dir, "missing.json"));
+    expect(state).toEqual(emptyState());
+  });
+
+  it("loads a valid state file", async () => {
+    const path = join(dir, "state.json");
+    const initial: TrafficNewsState = {
+      version: STATE_VERSION,
+      seenUrls: ["https://trafficnews.jp/post/12345", "https://trafficnews.jp/post/67890"],
+    };
+    await writeFile(path, JSON.stringify(initial), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(initial);
+  });
+
+  it("falls back to empty state on JSON parse error", async () => {
+    const path = join(dir, "broken.json");
+    await writeFile(path, "not json at all", "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+
+  it("falls back to empty state on version mismatch", async () => {
+    const path = join(dir, "oldversion.json");
+    await writeFile(path, JSON.stringify({ version: 0, seenUrls: [] }), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+
+  it("falls back to empty state when seenUrls is not an array", async () => {
+    const path = join(dir, "badschema.json");
+    await writeFile(path, JSON.stringify({ version: STATE_VERSION, seenUrls: "not-an-array" }), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+
+  it("falls back to empty state when seenUrls contains non-strings", async () => {
+    const path = join(dir, "badentries.json");
+    await writeFile(path, JSON.stringify({ version: STATE_VERSION, seenUrls: [42, true] }), "utf8");
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(emptyState());
+  });
+});
+
+describe("saveState", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "trafficnews-save-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes state atomically and is round-trippable", async () => {
+    const path = join(dir, "nested/a/b/state.json");
+    const state: TrafficNewsState = {
+      version: STATE_VERSION,
+      seenUrls: ["https://trafficnews.jp/post/12345"],
+    };
+    await saveState(state, path);
+    const raw = await readFile(path, "utf8");
+    expect(JSON.parse(raw)).toEqual(state);
+
+    const loaded = await loadState(path);
+    expect(loaded).toEqual(state);
+  });
+});


### PR DESCRIPTION
## Summary
This PR introduces a new trafficnews module that scrapes traffic news articles from trafficnews.jp, tracks seen articles, and outputs new ones as JSON. The implementation includes article extraction, state persistence, and comprehensive test coverage.

## Key Changes
- **Article Scraping**: Added `extractArticles()` function that parses HTML to extract article titles and URLs from trafficnews.jp, with fallback logic for different HTML structures and deduplication
- **State Management**: Implemented persistent state tracking via `loadState()` and `saveState()` functions that:
  - Store seen article URLs to avoid duplicate reporting
  - Support XDG Base Directory specification with fallback to `~/.local/state`
  - Allow override via `TRAFFICNEWS_STATE_FILE` environment variable or `--state` CLI argument
  - Use atomic writes (write-to-temp-then-rename) for data integrity
  - Include schema validation with version checking
- **CLI Interface**: Created `cli.ts` entry point that parses arguments, runs the scraper, and outputs results as JSON with timestamp
- **Filtering**: Added `filterNewArticles()` to identify articles not yet seen
- **Comprehensive Tests**: Added 261 lines of test coverage for:
  - Argument parsing with environment variable precedence
  - HTML extraction with edge cases (nested tags, deduplication, fallback patterns)
  - State loading/saving with error handling and schema validation
  - Path resolution (absolute/relative, XDG defaults)

## Notable Implementation Details
- Article extraction uses two-pass regex matching: first targets heading-wrapped links (primary pattern), then falls back to any post links if none found
- State validation is strict: rejects version mismatches, invalid schemas, and corrupted files by returning empty state
- Directory creation is automatic when saving state to nested paths
- HTML title processing strips inner tags and normalizes whitespace
- Fetch includes a User-Agent header for compatibility

https://claude.ai/code/session_018jE9U8CjtDXvrcTNTWqsXf