### PR TITLE
Limit article extraction to <main> element to exclude sidebar content

### DIFF
--- a/src/trafficnews/main.ts
+++ b/src/trafficnews/main.ts
@@ -33,6 +33,10 @@ export function parseArgs(argv: string[]): RunOptions {
 }
 
 export function extractArticles(html: string): ArticleEntry[] {
+  // Limit to <main> element to exclude sidebar widgets containing off-category articles
+  const mainMatch = html.match(/<main[\s\S]*?<\/main>/i);
+  const targetHtml = mainMatch ? mainMatch[0] : html;
+
   const seen = new Set<string>();
   const articles: ArticleEntry[] = [];
 
@@ -40,7 +44,7 @@ export function extractArticles(html: string): ArticleEntry[] {
   // Two passes: first look for headings containing links, then fall back to any post links.
   const headingPattern =
     /<h[1-6][^>]*>[\s\S]*?<a[^>]+href="(https:\/\/trafficnews\.jp\/post\/[^"]+)"[^>]*>([\s\S]*?)<\/a>[\s\S]*?<\/h[1-6]>/gi;
-  for (const match of html.matchAll(headingPattern)) {
+  for (const match of targetHtml.matchAll(headingPattern)) {
     const url = match[1];
     const rawTitle = match[2]
       .replace(/<[^>]+>/g, "")
@@ -55,7 +59,7 @@ export function extractArticles(html: string): ArticleEntry[] {
   // Fallback: any post links with non-empty anchor text not already captured
   if (articles.length === 0) {
     const linkPattern = /<a[^>]+href="(https:\/\/trafficnews\.jp\/post\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
-    for (const match of html.matchAll(linkPattern)) {
+    for (const match of targetHtml.matchAll(linkPattern)) {
       const url = match[1];
       const rawTitle = match[2]
         .replace(/<[^>]+>/g, "")

--- a/test/trafficnews/main.test.ts
+++ b/test/trafficnews/main.test.ts
@@ -46,17 +46,35 @@ describe("parseArgs", () => {
 describe("extractArticles", () => {
   it("extracts articles from heading-wrapped links", () => {
     const html = `
-      <h2 class="entry-title">
-        <a href="https://trafficnews.jp/post/12345">道路工事のお知らせ</a>
-      </h2>
-      <h2 class="entry-title">
-        <a href="https://trafficnews.jp/post/67890">新しい高速道路が開通</a>
-      </h2>
+      <main>
+        <h2 class="entry-title">
+          <a href="https://trafficnews.jp/post/12345">道路工事のお知らせ</a>
+        </h2>
+        <h2 class="entry-title">
+          <a href="https://trafficnews.jp/post/67890">新しい高速道路が開通</a>
+        </h2>
+      </main>
     `;
     const articles = extractArticles(html);
     expect(articles).toHaveLength(2);
     expect(articles[0]).toEqual({ title: "道路工事のお知らせ", url: "https://trafficnews.jp/post/12345" });
     expect(articles[1]).toEqual({ title: "新しい高速道路が開通", url: "https://trafficnews.jp/post/67890" });
+  });
+
+  it("ignores articles outside <main> (e.g. sidebar widgets)", () => {
+    const html = `
+      <main>
+        <h2 class="entry-title">
+          <a href="https://trafficnews.jp/post/11111">road記事</a>
+        </h2>
+      </main>
+      <aside>
+        <h2><a href="https://trafficnews.jp/post/99999">サイドバーの他カテゴリ記事</a></h2>
+      </aside>
+    `;
+    const articles = extractArticles(html);
+    expect(articles).toHaveLength(1);
+    expect(articles[0].url).toBe("https://trafficnews.jp/post/11111");
   });
 
   it("deduplicates articles with the same URL", () => {


### PR DESCRIPTION
## Summary
Modified the `extractArticles` function to only parse articles from within the `<main>` HTML element, preventing sidebar widgets and other off-category content from being incorrectly extracted as articles.

## Key Changes
- Added logic to extract and isolate the `<main>` element from the HTML before parsing articles
- Falls back to parsing the entire HTML if no `<main>` element is found
- Updated both the heading pattern and fallback link pattern to search only within the target HTML
- Added test case to verify that articles outside `<main>` (e.g., in `<aside>` elements) are properly ignored

## Implementation Details
The function now:
1. Uses a regex to find the `<main>...</main>` element in the HTML
2. Limits all subsequent article extraction patterns to search only within this element
3. Maintains backward compatibility by falling back to the full HTML if no `<main>` element exists
4. Preserves the existing deduplication and article extraction logic

https://claude.ai/code/session_01TpqgAD5soMoUCj9WM2Wrwc