### PR TITLE
Update article extraction to target section-archive-list instead of main

### DIFF
--- a/src/trafficnews/main.ts
+++ b/src/trafficnews/main.ts
@@ -33,9 +33,9 @@ export function parseArgs(argv: string[]): RunOptions {
 }
 
 export function extractArticles(html: string): ArticleEntry[] {
-  // Limit to <main> element to exclude sidebar widgets containing off-category articles
-  const mainMatch = html.match(/<main[\s\S]*?<\/main>/i);
-  const targetHtml = mainMatch ? mainMatch[0] : html;
+  // Limit to <section class="section-archive-list"> to exclude sidebar widgets containing off-category articles
+  const sectionMatch = html.match(/<section[^>]*class="[^"]*section-archive-list[^"]*"[^>]*>[\s\S]*?<\/section>/i);
+  const targetHtml = sectionMatch ? sectionMatch[0] : html;
 
   const seen = new Set<string>();
   const articles: ArticleEntry[] = [];

--- a/test/trafficnews/main.test.ts
+++ b/test/trafficnews/main.test.ts
@@ -46,14 +46,14 @@ describe("parseArgs", () => {
 describe("extractArticles", () => {
   it("extracts articles from heading-wrapped links", () => {
     const html = `
-      <main>
+      <section class="section-archive-list">
         <h2 class="entry-title">
           <a href="https://trafficnews.jp/post/12345">道路工事のお知らせ</a>
         </h2>
         <h2 class="entry-title">
           <a href="https://trafficnews.jp/post/67890">新しい高速道路が開通</a>
         </h2>
-      </main>
+      </section>
     `;
     const articles = extractArticles(html);
     expect(articles).toHaveLength(2);
@@ -61,13 +61,13 @@ describe("extractArticles", () => {
     expect(articles[1]).toEqual({ title: "新しい高速道路が開通", url: "https://trafficnews.jp/post/67890" });
   });
 
-  it("ignores articles outside <main> (e.g. sidebar widgets)", () => {
+  it('ignores articles outside <section class="section-archive-list"> (e.g. sidebar widgets)', () => {
     const html = `
-      <main>
+      <section class="section-archive-list">
         <h2 class="entry-title">
           <a href="https://trafficnews.jp/post/11111">road記事</a>
         </h2>
-      </main>
+      </section>
       <aside>
         <h2><a href="https://trafficnews.jp/post/99999">サイドバーの他カテゴリ記事</a></h2>
       </aside>


### PR DESCRIPTION
## Summary
Updated the article extraction logic to target a more specific HTML structure (`<section class="section-archive-list">`) instead of the generic `<main>` element. This change improves the robustness of article parsing by being more explicit about the expected page layout.

## Key Changes
- Modified `extractArticles()` function to search for `<section class="section-archive-list">` instead of `<main>` element
- Updated the regex pattern to properly match the section element with the specific class attribute
- Updated corresponding test cases to reflect the new HTML structure
- Added `/test_output.txt` to `.gitignore`

## Implementation Details
- The new regex pattern `/<section[^>]*class="[^"]*section-archive-list[^"]*"[^>]*>[\s\S]*?<\/section>/i` is more specific and handles class attributes that may contain multiple classes
- The fallback behavior remains the same: if the target section is not found, the entire HTML is processed
- This change makes the scraper less susceptible to layout changes while remaining flexible enough to handle variations in the HTML structure

https://claude.ai/code/session_016xWtqUeK6Sg2SRewfrDzLJ