### PR TITLE
feat(ghscan): include pull request list in scan output

### DIFF
--- a/src/ghscan/main.ts
+++ b/src/ghscan/main.ts
@@ -1,6 +1,6 @@
 import type { VersionTuple } from "../github/languageVersionFetcher.js";
 import { fetchLatestLanguageVersions } from "../github/languageVersionFetcher.js";
-import type { Repository } from "../github/repository.js";
+import type { PullRequest, Repository } from "../github/repository.js";
 import { fetchRepositories } from "../github/repositoryFetcher.js";
 
 // ── Public API ──────────────────────────────────────────────
@@ -8,7 +8,7 @@ import { fetchRepositories } from "../github/repositoryFetcher.js";
 export interface ScanResult {
   name: string;
   url: string;
-  pullRequestsCount: number;
+  pullRequests: PullRequest[];
   outdatedLanguages: string[];
   noActionlint: boolean;
 }
@@ -57,7 +57,7 @@ export function toScanResult(repo: Repository, latestVersions: ReadonlyMap<strin
   return {
     name: repo.name,
     url: repo.url,
-    pullRequestsCount: repo.pullRequestsCount,
+    pullRequests: repo.pullRequests,
     outdatedLanguages: detectOutdatedLanguages(repo, latestVersions),
     noActionlint: repo.noActionlint,
   };
@@ -67,7 +67,7 @@ export function toScanResult(repo: Repository, latestVersions: ReadonlyMap<strin
 
 export function filterScanResults(results: readonly ScanResult[]): ScanResult[] {
   return results.filter(
-    (result) => result.pullRequestsCount >= 1 || result.outdatedLanguages.length > 0 || result.noActionlint,
+    (result) => result.pullRequests.length >= 1 || result.outdatedLanguages.length > 0 || result.noActionlint,
   );
 }
 

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -1,7 +1,12 @@
+export interface PullRequest {
+  title: string;
+  url: string;
+}
+
 export interface Repository {
   name: string;
   url: string;
-  pullRequestsCount: number;
+  pullRequests: PullRequest[];
   languageVersions: Record<string, string[]>;
   noActionlint: boolean;
 }

--- a/src/github/repositoryFetcher.ts
+++ b/src/github/repositoryFetcher.ts
@@ -1,6 +1,6 @@
 import { RequestError } from "@octokit/request-error";
 import type { Octokit } from "@octokit/rest";
-import type { Repository } from "./repository.js";
+import type { PullRequest, Repository } from "./repository.js";
 import { analyzeWorkflows } from "./workflowParser.js";
 
 type OctokitRepo = Awaited<ReturnType<Octokit["rest"]["repos"]["listForAuthenticatedUser"]>>["data"][number];
@@ -37,27 +37,27 @@ async function getLogin(client: Octokit): Promise<string> {
 }
 
 async function buildRepository(client: Octokit, login: string, repo: OctokitRepo): Promise<Repository> {
-  const [prCount, workflows] = await Promise.all([
-    fetchPullRequestCount(client, login, repo.name),
+  const [pullRequests, workflows] = await Promise.all([
+    fetchPullRequests(client, login, repo.name),
     analyzeWorkflows(client, `${login}/${repo.name}`),
   ]);
 
   return {
     name: repo.name,
     url: repo.html_url,
-    pullRequestsCount: prCount,
+    pullRequests,
     languageVersions: workflows.languageVersions,
     noActionlint: workflows.noActionlint,
   };
 }
 
-async function fetchPullRequestCount(client: Octokit, owner: string, repo: string): Promise<number> {
+async function fetchPullRequests(client: Octokit, owner: string, repo: string): Promise<PullRequest[]> {
   try {
     const pulls = await client.rest.pulls.list({ owner, repo, state: "open" });
-    return pulls.data.length;
+    return pulls.data.map((pr) => ({ title: pr.title, url: pr.html_url }));
   } catch (error: unknown) {
     if (error instanceof RequestError && (error.status === 403 || error.status === 404)) {
-      return 0;
+      return [];
     }
     throw error;
   }

--- a/test/ghscan/main.test.ts
+++ b/test/ghscan/main.test.ts
@@ -9,7 +9,7 @@ function repo(overrides: Partial<Repository> = {}): Repository {
   return {
     name: "repo",
     url: "https://github.com/testuser/repo",
-    pullRequestsCount: 0,
+    pullRequests: [],
     languageVersions: {},
     noActionlint: false,
     ...overrides,
@@ -20,7 +20,7 @@ function scanResult(overrides: Partial<ScanResult> = {}): ScanResult {
   return {
     name: "repo",
     url: "https://github.com/testuser/repo",
-    pullRequestsCount: 0,
+    pullRequests: [],
     outdatedLanguages: [],
     noActionlint: false,
     ...overrides,
@@ -40,10 +40,16 @@ describe("toScanResult", () => {
     expect(result).toEqual({
       name: "my-repo",
       url: "https://github.com/testuser/repo",
-      pullRequestsCount: 0,
+      pullRequests: [],
       outdatedLanguages: ["ruby"],
       noActionlint: false,
     });
+  });
+
+  it("passes through pull requests from the repository", () => {
+    const pullRequests = [{ title: "Fix bug", url: "https://github.com/testuser/repo/pull/1" }];
+    const result = toScanResult(repo({ pullRequests }), latestVersions);
+    expect(result.pullRequests).toEqual(pullRequests);
   });
 
   it("excludes languageVersions from the result", () => {
@@ -56,11 +62,12 @@ describe("toScanResult", () => {
 
 describe("filterScanResults", () => {
   it("returns only results with at least one open PR", () => {
+    const pr = { title: "t", url: "u" };
     const results = [
-      scanResult({ name: "repo1", pullRequestsCount: 0 }),
-      scanResult({ name: "repo2", pullRequestsCount: 2 }),
-      scanResult({ name: "repo3", pullRequestsCount: 0 }),
-      scanResult({ name: "repo4", pullRequestsCount: 3 }),
+      scanResult({ name: "repo1", pullRequests: [] }),
+      scanResult({ name: "repo2", pullRequests: [pr, pr] }),
+      scanResult({ name: "repo3", pullRequests: [] }),
+      scanResult({ name: "repo4", pullRequests: [pr, pr, pr] }),
     ];
     expect(filterScanResults(results).map((r) => r.name)).toEqual(["repo2", "repo4"]);
   });

--- a/test/github/repositoryFetcher.test.ts
+++ b/test/github/repositoryFetcher.test.ts
@@ -68,8 +68,12 @@ describe("fetchRepositories", () => {
     const client = buildClient({
       repos,
       pullsByRepo: {
-        "testuser/repo1": [{}, {}, {}],
-        "testuser/repo2": [{}],
+        "testuser/repo1": [
+          { title: "PR one", html_url: "https://github.com/testuser/repo1/pull/1" },
+          { title: "PR two", html_url: "https://github.com/testuser/repo1/pull/2" },
+          { title: "PR three", html_url: "https://github.com/testuser/repo1/pull/3" },
+        ],
+        "testuser/repo2": [{ title: "Only PR", html_url: "https://github.com/testuser/repo2/pull/1" }],
       },
     });
 
@@ -78,11 +82,15 @@ describe("fetchRepositories", () => {
     expect(result[0]).toEqual({
       name: "repo1",
       url: "https://github.com/testuser/repo1",
-      pullRequestsCount: 3,
+      pullRequests: [
+        { title: "PR one", url: "https://github.com/testuser/repo1/pull/1" },
+        { title: "PR two", url: "https://github.com/testuser/repo1/pull/2" },
+        { title: "PR three", url: "https://github.com/testuser/repo1/pull/3" },
+      ],
       languageVersions: {},
       noActionlint: false,
     });
-    expect(result[1]?.pullRequestsCount).toBe(1);
+    expect(result[1]?.pullRequests).toEqual([{ title: "Only PR", url: "https://github.com/testuser/repo2/pull/1" }]);
   });
 
   it("returns empty array when user has no repositories", async () => {
@@ -118,7 +126,7 @@ describe("fetchRepositories", () => {
     expect(result[0]?.languageVersions).toEqual({ ruby: ["3.1", "3.2"] });
   });
 
-  it("returns 0 pull request count when access is forbidden (403)", async () => {
+  it("returns empty pull request list when access is forbidden (403)", async () => {
     const repos = [fakeRepo({ name: "repo1", html_url: "https://github.com/testuser/repo1" })];
     const client = buildClient({ repos });
     vi.mocked(client.rest.pulls.list as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -128,7 +136,7 @@ describe("fetchRepositories", () => {
     );
 
     const result = await fetchRepositories(client);
-    expect(result[0]?.pullRequestsCount).toBe(0);
+    expect(result[0]?.pullRequests).toEqual([]);
   });
 
   it("fetches PR count and workflows concurrently per repo", async () => {


### PR DESCRIPTION
Replace pullRequestsCount with a pullRequests array of { title, url }
so the output identifies each open PR rather than just the count.

https://claude.ai/code/session_01EAVtnP3VPTybuM6LrUEVyz