### PR TITLE
feat(ghscan): add --label option to filter PRs by labels

### DIFF
--- a/src/ghscan/cli.ts
+++ b/src/ghscan/cli.ts
@@ -1,8 +1,7 @@
 import "dotenv/config";
-import { run } from "./main.js";
+import { parseArgs, run } from "./main.js";
 
-const debug = process.argv.includes("--debug");
-run({ debug }).catch((error) => {
+run(parseArgs(process.argv)).catch((error) => {
   console.error(error);
   process.exit(1);
 });

--- a/src/ghscan/main.ts
+++ b/src/ghscan/main.ts
@@ -1,3 +1,4 @@
+import { parseArgs as nodeParseArgs } from "node:util";
 import type { VersionTuple } from "../github/languageVersionFetcher.js";
 import { fetchLatestLanguageVersions } from "../github/languageVersionFetcher.js";
 import type { PullRequest, Repository } from "../github/repository.js";
@@ -14,10 +15,27 @@ export interface ScanResult {
 }
 
 export interface RunOptions {
-  debug?: boolean;
+  debug: boolean;
+  labels: readonly string[];
 }
 
-export async function run({ debug = false }: RunOptions = {}): Promise<void> {
+export function parseArgs(argv: string[]): RunOptions {
+  const { values } = nodeParseArgs({
+    args: argv.slice(2),
+    options: {
+      debug: { type: "boolean" },
+      label: { type: "string", multiple: true },
+    },
+    allowPositionals: false,
+  });
+
+  return {
+    debug: values.debug ?? false,
+    labels: values.label ?? [],
+  };
+}
+
+export async function run({ debug, labels }: RunOptions): Promise<void> {
   const token = requireToken();
   const { Octokit } = await import("@octokit/rest");
   const client = new Octokit({
@@ -31,7 +49,7 @@ export async function run({ debug = false }: RunOptions = {}): Promise<void> {
   });
 
   const [repositories, latestVersions] = await Promise.all([
-    fetchRepositories(client, { debug }),
+    fetchRepositories(client, { debug, labels }),
     fetchLatestLanguageVersions(client),
   ]);
 

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -1,6 +1,7 @@
 export interface PullRequest {
   title: string;
   url: string;
+  labels: string[];
 }
 
 export interface Repository {

--- a/src/github/repositoryFetcher.ts
+++ b/src/github/repositoryFetcher.ts
@@ -9,13 +9,17 @@ const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 export interface FetchOptions {
   debug?: boolean;
+  labels?: readonly string[];
 }
 
 export function isActiveRepo(repo: OctokitRepo): boolean {
   return !repo.archived && !repo.fork && new Date(repo.pushed_at ?? 0).getTime() > Date.now() - ONE_YEAR_MS;
 }
 
-export async function fetchRepositories(client: Octokit, { debug = false }: FetchOptions = {}): Promise<Repository[]> {
+export async function fetchRepositories(
+  client: Octokit,
+  { debug = false, labels = [] }: FetchOptions = {},
+): Promise<Repository[]> {
   const login = await getLogin(client);
   const allRepos = await client.paginate(client.rest.repos.listForAuthenticatedUser, { type: "owner" });
   if (debug) console.warn(`[debug] Found ${allRepos.length} repositories`);
@@ -26,7 +30,7 @@ export async function fetchRepositories(client: Octokit, { debug = false }: Fetc
   return Promise.all(
     activeRepos.map((repo, i) => {
       if (debug) console.warn(`[debug] Processing ${repo.name} (${i + 1}/${activeRepos.length})`);
-      return buildRepository(client, login, repo);
+      return buildRepository(client, login, repo, labels);
     }),
   );
 }
@@ -36,9 +40,14 @@ async function getLogin(client: Octokit): Promise<string> {
   return user.login;
 }
 
-async function buildRepository(client: Octokit, login: string, repo: OctokitRepo): Promise<Repository> {
+async function buildRepository(
+  client: Octokit,
+  login: string,
+  repo: OctokitRepo,
+  labels: readonly string[],
+): Promise<Repository> {
   const [pullRequests, workflows] = await Promise.all([
-    fetchPullRequests(client, login, repo.name),
+    fetchPullRequests(client, login, repo.name, labels),
     analyzeWorkflows(client, `${login}/${repo.name}`),
   ]);
 
@@ -51,10 +60,20 @@ async function buildRepository(client: Octokit, login: string, repo: OctokitRepo
   };
 }
 
-async function fetchPullRequests(client: Octokit, owner: string, repo: string): Promise<PullRequest[]> {
+async function fetchPullRequests(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  labels: readonly string[],
+): Promise<PullRequest[]> {
   try {
     const pulls = await client.rest.pulls.list({ owner, repo, state: "open" });
-    return pulls.data.map((pr) => ({ title: pr.title, url: pr.html_url }));
+    const all = pulls.data.map((pr) => ({
+      title: pr.title,
+      url: pr.html_url,
+      labels: pr.labels.map((l) => l.name),
+    }));
+    return labels.length === 0 ? all : all.filter((pr) => labels.every((l) => pr.labels.includes(l)));
   } catch (error: unknown) {
     if (error instanceof RequestError && (error.status === 403 || error.status === 404)) {
       return [];

--- a/test/ghscan/main.test.ts
+++ b/test/ghscan/main.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { ScanResult } from "@/ghscan/main.js";
-import { detectOutdatedLanguages, filterScanResults, parseMinorVersion, toScanResult } from "@/ghscan/main.js";
+import {
+  detectOutdatedLanguages,
+  filterScanResults,
+  parseArgs,
+  parseMinorVersion,
+  toScanResult,
+} from "@/ghscan/main.js";
 import type { Repository } from "@/github/repository.js";
 
 // ── Helpers ─────────────────────────────────────────────────
@@ -47,7 +53,7 @@ describe("toScanResult", () => {
   });
 
   it("passes through pull requests from the repository", () => {
-    const pullRequests = [{ title: "Fix bug", url: "https://github.com/testuser/repo/pull/1" }];
+    const pullRequests = [{ title: "Fix bug", url: "https://github.com/testuser/repo/pull/1", labels: [] }];
     const result = toScanResult(repo({ pullRequests }), latestVersions);
     expect(result.pullRequests).toEqual(pullRequests);
   });
@@ -62,7 +68,7 @@ describe("toScanResult", () => {
 
 describe("filterScanResults", () => {
   it("returns only results with at least one open PR", () => {
-    const pr = { title: "t", url: "u" };
+    const pr = { title: "t", url: "u", labels: [] };
     const results = [
       scanResult({ name: "repo1", pullRequests: [] }),
       scanResult({ name: "repo2", pullRequests: [pr, pr] }),
@@ -129,6 +135,27 @@ describe("detectOutdatedLanguages", () => {
   it("ignores untracked languages", () => {
     const result = detectOutdatedLanguages(repo({ languageVersions: { go: ["1.22"] } }), latestVersions);
     expect(result).toEqual([]);
+  });
+});
+
+// ── parseArgs ───────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  const argv = (...args: string[]) => ["node", "ghscan", ...args];
+
+  it("returns defaults when no flags are given", () => {
+    expect(parseArgs(argv())).toEqual({ debug: false, labels: [] });
+  });
+
+  it("parses --debug", () => {
+    expect(parseArgs(argv("--debug"))).toEqual({ debug: true, labels: [] });
+  });
+
+  it("collects multiple --label values", () => {
+    expect(parseArgs(argv("--label", "bug", "--label", "urgent"))).toEqual({
+      debug: false,
+      labels: ["bug", "urgent"],
+    });
   });
 });
 

--- a/test/github/repositoryFetcher.test.ts
+++ b/test/github/repositoryFetcher.test.ts
@@ -69,11 +69,11 @@ describe("fetchRepositories", () => {
       repos,
       pullsByRepo: {
         "testuser/repo1": [
-          { title: "PR one", html_url: "https://github.com/testuser/repo1/pull/1" },
-          { title: "PR two", html_url: "https://github.com/testuser/repo1/pull/2" },
-          { title: "PR three", html_url: "https://github.com/testuser/repo1/pull/3" },
+          { title: "PR one", html_url: "https://github.com/testuser/repo1/pull/1", labels: [] },
+          { title: "PR two", html_url: "https://github.com/testuser/repo1/pull/2", labels: [] },
+          { title: "PR three", html_url: "https://github.com/testuser/repo1/pull/3", labels: [] },
         ],
-        "testuser/repo2": [{ title: "Only PR", html_url: "https://github.com/testuser/repo2/pull/1" }],
+        "testuser/repo2": [{ title: "Only PR", html_url: "https://github.com/testuser/repo2/pull/1", labels: [] }],
       },
     });
 
@@ -83,14 +83,16 @@ describe("fetchRepositories", () => {
       name: "repo1",
       url: "https://github.com/testuser/repo1",
       pullRequests: [
-        { title: "PR one", url: "https://github.com/testuser/repo1/pull/1" },
-        { title: "PR two", url: "https://github.com/testuser/repo1/pull/2" },
-        { title: "PR three", url: "https://github.com/testuser/repo1/pull/3" },
+        { title: "PR one", url: "https://github.com/testuser/repo1/pull/1", labels: [] },
+        { title: "PR two", url: "https://github.com/testuser/repo1/pull/2", labels: [] },
+        { title: "PR three", url: "https://github.com/testuser/repo1/pull/3", labels: [] },
       ],
       languageVersions: {},
       noActionlint: false,
     });
-    expect(result[1]?.pullRequests).toEqual([{ title: "Only PR", url: "https://github.com/testuser/repo2/pull/1" }]);
+    expect(result[1]?.pullRequests).toEqual([
+      { title: "Only PR", url: "https://github.com/testuser/repo2/pull/1", labels: [] },
+    ]);
   });
 
   it("returns empty array when user has no repositories", async () => {
@@ -146,5 +148,59 @@ describe("fetchRepositories", () => {
     await fetchRepositories(client);
 
     expect(analyzeWorkflows).toHaveBeenCalledWith(client, "testuser/repo1");
+  });
+
+  it("includes PR labels in the result", async () => {
+    const repos = [fakeRepo({ name: "repo1" })];
+    const client = buildClient({
+      repos,
+      pullsByRepo: {
+        "testuser/repo1": [
+          {
+            title: "PR",
+            html_url: "https://github.com/testuser/repo1/pull/1",
+            labels: [{ name: "bug" }, { name: "urgent" }],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchRepositories(client);
+    expect(result[0]?.pullRequests).toEqual([
+      { title: "PR", url: "https://github.com/testuser/repo1/pull/1", labels: ["bug", "urgent"] },
+    ]);
+  });
+
+  it("filters PRs to those containing all specified labels", async () => {
+    const repos = [fakeRepo({ name: "repo1" })];
+    const client = buildClient({
+      repos,
+      pullsByRepo: {
+        "testuser/repo1": [
+          { title: "match", html_url: "u1", labels: [{ name: "bug" }, { name: "urgent" }] },
+          { title: "partial", html_url: "u2", labels: [{ name: "bug" }] },
+          { title: "none", html_url: "u3", labels: [] },
+        ],
+      },
+    });
+
+    const result = await fetchRepositories(client, { labels: ["bug", "urgent"] });
+    expect(result[0]?.pullRequests.map((pr) => pr.title)).toEqual(["match"]);
+  });
+
+  it("returns all PRs when no labels are specified", async () => {
+    const repos = [fakeRepo({ name: "repo1" })];
+    const client = buildClient({
+      repos,
+      pullsByRepo: {
+        "testuser/repo1": [
+          { title: "a", html_url: "u1", labels: [{ name: "bug" }] },
+          { title: "b", html_url: "u2", labels: [] },
+        ],
+      },
+    });
+
+    const result = await fetchRepositories(client, { labels: [] });
+    expect(result[0]?.pullRequests).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Allow narrowing the PR list included in ghscan output to those that carry
all specified labels. Multiple --label flags can be supplied; each PR must
include every specified label to be kept.