### PR TITLE
Rename deleteCompleted action to purge

### DIFF
--- a/gas/shopping_list/src/main.ts
+++ b/gas/shopping_list/src/main.ts
@@ -1,7 +1,7 @@
 type PostBody =
   | { action: "add"; items: string[] }
   | { action: "update"; updates: UpdateRequest[] }
-  | { action: "deleteCompleted" };
+  | { action: "purge" };
 
 function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.Content.TextOutput {
   const action = e.parameter.action;
@@ -34,8 +34,8 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
       case "update":
         updateCheckedState(body.updates);
         return jsonOutput({ success: true });
-      case "deleteCompleted": {
-        const deleted = deleteCompletedItems();
+      case "purge": {
+        const deleted = purgeCompletedItems();
         return jsonOutput<{ deleted: number }>({ success: true, data: { deleted } });
       }
       default:

--- a/gas/shopping_list/src/spreadsheet.ts
+++ b/gas/shopping_list/src/spreadsheet.ts
@@ -41,7 +41,7 @@ function updateCheckedState(updates: UpdateRequest[]): void {
   });
 }
 
-function deleteCompletedItems(): number {
+function purgeCompletedItems(): number {
   const sheet = getSheet();
   const lastRow = sheet.getLastRow();
   if (lastRow <= 1) return 0;


### PR DESCRIPTION
## Summary
Renamed the "deleteCompleted" action to "purge" for better clarity and consistency in the shopping list API.

## Changes
- Renamed POST action from `"deleteCompleted"` to `"purge"` in the PostBody type
- Updated the corresponding case statement in `doPost()` to handle the new `"purge"` action
- Renamed `deleteCompletedItems()` function to `purgeCompletedItems()` for consistency with the new action name

## Details
This change improves the naming convention by using "purge" as a more descriptive term for the operation that removes all completed items from the shopping list. The functionality remains unchanged; only the naming has been updated for better API clarity.

https://claude.ai/code/session_01FgFpNdSPCkjW9wyzKm6tQG