### PR TITLE
Add Slack checkbox payload parser utility

### DIFF
--- a/src/slackutils/checkboxes/cli.ts
+++ b/src/slackutils/checkboxes/cli.ts
@@ -1,0 +1,32 @@
+import { parseCheckboxPayload } from "./main.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+async function main(): Promise<void> {
+  const raw = (await readStdin()).trim();
+  if (!raw) {
+    console.error("Error: stdin is empty");
+    process.exit(1);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch (error) {
+    console.error(`Error: invalid JSON on stdin: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  console.log(JSON.stringify(parseCheckboxPayload(payload)));
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/slackutils/checkboxes/main.ts
+++ b/src/slackutils/checkboxes/main.ts
@@ -1,0 +1,63 @@
+export type CheckboxStateMap = Record<string, boolean>;
+
+interface CheckboxOption {
+  value?: unknown;
+}
+
+interface BlockElement {
+  type?: unknown;
+  options?: unknown;
+}
+
+interface Block {
+  type?: unknown;
+  elements?: unknown;
+}
+
+interface StateAction {
+  type?: unknown;
+  selected_options?: unknown;
+}
+
+interface BlockActionsPayload {
+  message?: { blocks?: unknown };
+  state?: { values?: unknown };
+}
+
+export function parseCheckboxPayload(payload: unknown): CheckboxStateMap {
+  const result: CheckboxStateMap = {};
+  const p = (payload ?? {}) as BlockActionsPayload;
+
+  // Collect every checkbox option from the original message as the universe (default: false).
+  const blocks = Array.isArray(p.message?.blocks) ? (p.message?.blocks as Block[]) : [];
+  for (const block of blocks) {
+    if (block?.type !== "actions" || !Array.isArray(block.elements)) continue;
+    for (const element of block.elements as BlockElement[]) {
+      if (element?.type !== "checkboxes" || !Array.isArray(element.options)) continue;
+      for (const option of element.options as CheckboxOption[]) {
+        if (typeof option?.value === "string") {
+          result[option.value] = false;
+        }
+      }
+    }
+  }
+
+  // Overlay selected options from state.values. Values not already registered are still
+  // included as true so a caller can parse state-only payloads without data loss.
+  const stateValues = p.state?.values;
+  if (stateValues && typeof stateValues === "object") {
+    for (const blockState of Object.values(stateValues as Record<string, unknown>)) {
+      if (!blockState || typeof blockState !== "object") continue;
+      for (const action of Object.values(blockState as Record<string, StateAction>)) {
+        if (action?.type !== "checkboxes" || !Array.isArray(action.selected_options)) continue;
+        for (const option of action.selected_options as CheckboxOption[]) {
+          if (typeof option?.value === "string") {
+            result[option.value] = true;
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/test/slackutils/checkboxes/main.test.ts
+++ b/test/slackutils/checkboxes/main.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { parseCheckboxPayload } from "@/slackutils/checkboxes/main.js";
+
+describe("parseCheckboxPayload", () => {
+  it("returns an empty map for an empty payload", () => {
+    expect(parseCheckboxPayload({})).toEqual({});
+  });
+
+  it("defaults every option from message.blocks to false when no state is provided", () => {
+    const payload = {
+      message: {
+        blocks: [
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "checkboxes",
+                action_id: "checkbox_action_1",
+                options: [
+                  { value: "1", text: { type: "plain_text", text: "apple" } },
+                  { value: "2", text: { type: "plain_text", text: "banana" } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ "1": false, "2": false });
+  });
+
+  it("marks options selected in state.values as true", () => {
+    const payload = {
+      message: {
+        blocks: [
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "checkboxes",
+                action_id: "checkbox_action_1",
+                options: [{ value: "1" }, { value: "2" }, { value: "3" }],
+              },
+            ],
+          },
+        ],
+      },
+      state: {
+        values: {
+          block_x: {
+            checkbox_action_1: {
+              type: "checkboxes",
+              selected_options: [{ value: "1" }, { value: "3" }],
+            },
+          },
+        },
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ "1": true, "2": false, "3": true });
+  });
+
+  it("merges options across multiple actions blocks", () => {
+    const payload = {
+      message: {
+        blocks: [
+          {
+            type: "actions",
+            elements: [
+              { type: "checkboxes", action_id: "checkbox_action_1", options: [{ value: "1" }, { value: "2" }] },
+            ],
+          },
+          {
+            type: "actions",
+            elements: [
+              { type: "checkboxes", action_id: "checkbox_action_2", options: [{ value: "3" }, { value: "4" }] },
+            ],
+          },
+        ],
+      },
+      state: {
+        values: {
+          block_a: { checkbox_action_1: { type: "checkboxes", selected_options: [{ value: "2" }] } },
+          block_b: { checkbox_action_2: { type: "checkboxes", selected_options: [{ value: "3" }] } },
+        },
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ "1": false, "2": true, "3": true, "4": false });
+  });
+
+  it("ignores non-actions blocks and non-checkboxes elements", () => {
+    const payload = {
+      message: {
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text: "hello" } },
+          {
+            type: "actions",
+            elements: [
+              { type: "button", action_id: "btn", text: { type: "plain_text", text: "click" } },
+              { type: "checkboxes", action_id: "checkbox_action_1", options: [{ value: "1" }] },
+            ],
+          },
+        ],
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ "1": false });
+  });
+
+  it("ignores state entries that are not checkboxes actions", () => {
+    const payload = {
+      message: {
+        blocks: [{ type: "actions", elements: [{ type: "checkboxes", options: [{ value: "1" }, { value: "2" }] }] }],
+      },
+      state: {
+        values: {
+          block_x: {
+            some_button: { type: "button", value: "clicked" },
+            checkbox_action: { type: "checkboxes", selected_options: [{ value: "2" }] },
+          },
+        },
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ "1": false, "2": true });
+  });
+
+  it("includes selected values that have no matching message option", () => {
+    // Edge case: state-only payload or options removed between send and response.
+    const payload = {
+      state: {
+        values: {
+          block_x: {
+            checkbox_action: { type: "checkboxes", selected_options: [{ value: "orphan" }] },
+          },
+        },
+      },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({ orphan: true });
+  });
+
+  it("treats null payload as empty", () => {
+    expect(parseCheckboxPayload(null)).toEqual({});
+  });
+
+  it("tolerates malformed blocks without throwing", () => {
+    const payload = {
+      message: { blocks: "not-an-array" },
+      state: { values: "not-an-object" },
+    };
+    expect(parseCheckboxPayload(payload)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
This PR introduces a new utility module for parsing Slack block actions payloads containing checkbox elements. It provides both a core parsing function and a CLI interface for processing checkbox state from Slack interactive messages.

## Key Changes
- **Core parser (`src/slack-checkbox/main.ts`)**: Implements `parseCheckboxPayload()` function that:
  - Extracts all checkbox options from message blocks and defaults them to `false`
  - Overlays selected options from the state payload, marking them as `true`
  - Handles edge cases like state-only payloads, malformed data, and missing options
  - Returns a `CheckboxStateMap` (Record<string, boolean>) mapping option values to their selection state

- **CLI interface (`src/slack-checkbox/cli.ts`)**: Provides a command-line tool that:
  - Reads JSON payload from stdin
  - Parses it using the core function
  - Outputs the checkbox state map as JSON
  - Includes proper error handling for empty input and invalid JSON

- **Comprehensive test suite (`test/slack-checkbox/main.test.ts`)**: Covers:
  - Empty payloads
  - Default false values for all options
  - Selected state overlay
  - Multiple checkbox actions across blocks
  - Filtering of non-checkbox elements and blocks
  - Edge cases (orphaned selections, null payloads, malformed data)

## Notable Implementation Details
- Defensive programming with type guards and array checks to tolerate malformed payloads
- Supports state-only payloads without message blocks for flexibility
- Preserves selected values even if they don't exist in the original message options
- All string values are properly validated before inclusion in results

https://claude.ai/code/session_01DicDCU68ro2Kgkdxev9JLD