### PR TITLE
Add shopping_list CLI for n8n workflow migration

### DIFF
--- a/src/shopping_list/blockkit.ts
+++ b/src/shopping_list/blockkit.ts
@@ -1,0 +1,53 @@
+import type { ShoppingItem } from "./gas.js";
+
+const CHUNK_SIZE = 10;
+
+interface CheckboxOption {
+  text: { type: "plain_text"; text: string };
+  value: string;
+}
+
+interface CheckboxesElement {
+  type: "checkboxes";
+  action_id: string;
+  options: CheckboxOption[];
+}
+
+interface SectionBlock {
+  type: "section";
+  text: { type: "mrkdwn"; text: string };
+}
+
+interface ActionsBlock {
+  type: "actions";
+  elements: CheckboxesElement[];
+}
+
+export type BlockKitBlock = SectionBlock | ActionsBlock;
+
+export function buildBlocks(items: ShoppingItem[]): BlockKitBlock[] {
+  if (items.length === 0) {
+    return [{ type: "section", text: { type: "mrkdwn", text: "買い物リストは空です" } }];
+  }
+
+  const actionBlocks: ActionsBlock[] = [];
+  for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+    const chunk = items.slice(i, i + CHUNK_SIZE);
+    const index = Math.floor(i / CHUNK_SIZE) + 1;
+    actionBlocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "checkboxes",
+          action_id: `checkbox_action_${index}`,
+          options: chunk.map((item) => ({
+            text: { type: "plain_text", text: item.items },
+            value: String(item.id),
+          })),
+        },
+      ],
+    });
+  }
+
+  return [{ type: "section", text: { type: "mrkdwn", text: "買い物リスト：" } }, ...actionBlocks];
+}

--- a/src/shopping_list/cli.ts
+++ b/src/shopping_list/cli.ts
@@ -1,0 +1,11 @@
+import "dotenv/config";
+import { parseArgs, run } from "./main.js";
+
+run(parseArgs(process.argv))
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error) => {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });

--- a/src/shopping_list/gas.ts
+++ b/src/shopping_list/gas.ts
@@ -1,0 +1,78 @@
+export interface ShoppingItem {
+  id: number;
+  items: string;
+  disabled: boolean;
+}
+
+export interface UpdateRequest {
+  id: number;
+  checked: boolean;
+}
+
+interface GasResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface GasClientApi {
+  list(): Promise<ShoppingItem[]>;
+  add(items: string[]): Promise<void>;
+  update(updates: UpdateRequest[]): Promise<void>;
+  purge(): Promise<number>;
+}
+
+async function parseResponse<T>(res: Response): Promise<T | undefined> {
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+  const json = (await res.json()) as GasResponse<T>;
+  if (!json.success) {
+    throw new Error(json.error ?? "GAS request failed");
+  }
+  return json.data;
+}
+
+export class GasClient implements GasClientApi {
+  constructor(
+    private readonly url: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async list(): Promise<ShoppingItem[]> {
+    return (await this.get<ShoppingItem[]>("list")) ?? [];
+  }
+
+  async add(items: string[]): Promise<void> {
+    await this.post({ action: "add", items });
+  }
+
+  async update(updates: UpdateRequest[]): Promise<void> {
+    // GAS still expects the legacy `rowNumber` key on the wire; map at the boundary.
+    const wireUpdates = updates.map((u) => ({ rowNumber: u.id, checked: u.checked }));
+    await this.post({ action: "update", updates: wireUpdates });
+  }
+
+  async purge(): Promise<number> {
+    const data = await this.post<{ deleted: number }>({ action: "purge" });
+    return data?.deleted ?? 0;
+  }
+
+  private async get<T>(action: string): Promise<T | undefined> {
+    const res = await this.fetchImpl(`${this.url}?action=${encodeURIComponent(action)}`, {
+      method: "GET",
+      redirect: "follow",
+    });
+    return parseResponse<T>(res);
+  }
+
+  private async post<T>(body: unknown): Promise<T | undefined> {
+    const res = await this.fetchImpl(this.url, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain;charset=utf-8" },
+      body: JSON.stringify(body),
+      redirect: "follow",
+    });
+    return parseResponse<T>(res);
+  }
+}

--- a/src/shopping_list/main.ts
+++ b/src/shopping_list/main.ts
@@ -1,0 +1,124 @@
+import { type BlockKitBlock, buildBlocks } from "./blockkit.js";
+import { GasClient, type GasClientApi } from "./gas.js";
+import { splitItems, stripMentions } from "./mention.js";
+
+export type Subcommand = "dispatch" | "update" | "purge";
+
+export interface RunOptions {
+  subcommand: Subcommand;
+  text: string;
+}
+
+export interface DispatchListOutput {
+  success: true;
+  kind: "list";
+  blocks: BlockKitBlock[];
+}
+
+export interface DispatchAddOutput {
+  success: true;
+  kind: "added";
+  count: number;
+}
+
+export type DispatchOutput = DispatchListOutput | DispatchAddOutput;
+
+export interface UpdateOutput {
+  success: true;
+  updated: number;
+}
+
+export interface PurgeOutput {
+  success: true;
+  deleted: number;
+}
+
+export function parseArgs(argv: string[]): RunOptions {
+  const args = argv.slice(2);
+  const [subcommand, ...rest] = args;
+
+  switch (subcommand) {
+    case "dispatch":
+      return { subcommand: "dispatch", text: rest.join(" ") };
+    case "update":
+    case "purge":
+      return { subcommand, text: "" };
+    default:
+      throw new Error(`Unknown subcommand: ${subcommand ?? "(missing)"}. Use one of: dispatch, update, purge`);
+  }
+}
+
+function getGasUrl(): string {
+  const url = process.env.SHOPPING_LIST_GAS_URL;
+  if (!url) {
+    throw new Error("SHOPPING_LIST_GAS_URL is not set");
+  }
+  return url;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function runDispatch(text: string, client: GasClientApi): Promise<DispatchOutput> {
+  const argument = stripMentions(text);
+  if (argument === "") {
+    const items = await client.list();
+    return { success: true, kind: "list", blocks: buildBlocks(items) };
+  }
+  const items = splitItems(argument);
+  await client.add(items);
+  return { success: true, kind: "added", count: items.length };
+}
+
+export function toUpdateRequests(stateMap: Record<string, boolean>) {
+  return Object.entries(stateMap).map(([id, checked]) => ({
+    id: Number(id),
+    checked,
+  }));
+}
+
+export async function runUpdate(stateMap: Record<string, boolean>, client: GasClientApi): Promise<UpdateOutput> {
+  const updates = toUpdateRequests(stateMap);
+  await client.update(updates);
+  return { success: true, updated: updates.length };
+}
+
+export async function runPurge(client: GasClientApi): Promise<PurgeOutput> {
+  const deleted = await client.purge();
+  return { success: true, deleted };
+}
+
+export async function run(options: RunOptions): Promise<number> {
+  const client = new GasClient(getGasUrl());
+
+  switch (options.subcommand) {
+    case "dispatch": {
+      const output = await runDispatch(options.text, client);
+      console.log(JSON.stringify(output));
+      return 0;
+    }
+    case "update": {
+      const raw = (await readStdin()).trim();
+      if (!raw) throw new Error("stdin is empty");
+      let stateMap: Record<string, boolean>;
+      try {
+        stateMap = JSON.parse(raw) as Record<string, boolean>;
+      } catch (error) {
+        throw new Error(`invalid JSON on stdin: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      const output = await runUpdate(stateMap, client);
+      console.log(JSON.stringify(output));
+      return 0;
+    }
+    case "purge": {
+      const output = await runPurge(client);
+      console.log(JSON.stringify(output));
+      return 0;
+    }
+  }
+}

--- a/src/shopping_list/mention.ts
+++ b/src/shopping_list/mention.ts
@@ -1,0 +1,12 @@
+const MENTION_PATTERN = /<@.*?>/g;
+
+export function stripMentions(text: string): string {
+  return text.replace(MENTION_PATTERN, "").trim();
+}
+
+export function splitItems(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/test/shopping_list/blockkit.test.ts
+++ b/test/shopping_list/blockkit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildBlocks } from "@/shopping_list/blockkit.js";
+import type { ShoppingItem } from "@/shopping_list/gas.js";
+
+function item(id: number, name: string): ShoppingItem {
+  return { id, items: name, disabled: false };
+}
+
+describe("buildBlocks", () => {
+  it("returns an empty-list section when there are no items", () => {
+    expect(buildBlocks([])).toEqual([{ type: "section", text: { type: "mrkdwn", text: "買い物リストは空です" } }]);
+  });
+
+  it("builds a header section and a single actions block for up to 10 items", () => {
+    const items = [item(2, "牛乳"), item(3, "パン")];
+    const blocks = buildBlocks(items);
+
+    expect(blocks[0]).toEqual({ type: "section", text: { type: "mrkdwn", text: "買い物リスト：" } });
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1]).toEqual({
+      type: "actions",
+      elements: [
+        {
+          type: "checkboxes",
+          action_id: "checkbox_action_1",
+          options: [
+            { text: { type: "plain_text", text: "牛乳" }, value: "2" },
+            { text: { type: "plain_text", text: "パン" }, value: "3" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("chunks more than 10 items into multiple actions blocks with sequential action_ids", () => {
+    const items = Array.from({ length: 23 }, (_, i) => item(i + 2, `item-${i + 1}`));
+    const blocks = buildBlocks(items);
+
+    // 1 section + ceil(23/10) = 1 + 3 actions blocks
+    expect(blocks).toHaveLength(4);
+    const actions = blocks.slice(1) as Extract<(typeof blocks)[number], { type: "actions" }>[];
+    expect(actions.map((b) => b.elements[0].action_id)).toEqual([
+      "checkbox_action_1",
+      "checkbox_action_2",
+      "checkbox_action_3",
+    ]);
+    expect(actions[0].elements[0].options).toHaveLength(10);
+    expect(actions[1].elements[0].options).toHaveLength(10);
+    expect(actions[2].elements[0].options).toHaveLength(3);
+  });
+
+  it("uses id (as string) for the option value", () => {
+    const blocks = buildBlocks([item(7, "卵")]);
+    const actions = blocks[1] as Extract<(typeof blocks)[number], { type: "actions" }>;
+    expect(actions.elements[0].options[0].value).toBe("7");
+  });
+});

--- a/test/shopping_list/main.test.ts
+++ b/test/shopping_list/main.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GasClientApi, ShoppingItem, UpdateRequest } from "@/shopping_list/gas.js";
+import { parseArgs, runDispatch, runPurge, runUpdate, toUpdateRequests } from "@/shopping_list/main.js";
+
+function fakeClient(overrides: Partial<GasClientApi> = {}): GasClientApi {
+  return {
+    list: vi.fn(async () => [] as ShoppingItem[]),
+    add: vi.fn(async (_items: string[]) => {}),
+    update: vi.fn(async (_updates: UpdateRequest[]) => {}),
+    purge: vi.fn(async () => 0),
+    ...overrides,
+  };
+}
+
+describe("parseArgs", () => {
+  it("parses dispatch with text joined from positional args", () => {
+    expect(parseArgs(["node", "cli", "dispatch", "<@U1>", "牛乳"])).toEqual({
+      subcommand: "dispatch",
+      text: "<@U1> 牛乳",
+    });
+  });
+
+  it("parses dispatch with empty text when no positional follows", () => {
+    expect(parseArgs(["node", "cli", "dispatch"])).toEqual({ subcommand: "dispatch", text: "" });
+  });
+
+  it("parses update and purge", () => {
+    expect(parseArgs(["node", "cli", "update"])).toEqual({ subcommand: "update", text: "" });
+    expect(parseArgs(["node", "cli", "purge"])).toEqual({ subcommand: "purge", text: "" });
+  });
+
+  it("throws on unknown subcommand", () => {
+    expect(() => parseArgs(["node", "cli", "wat"])).toThrow(/Unknown subcommand/);
+  });
+
+  it("throws when no subcommand is given", () => {
+    expect(() => parseArgs(["node", "cli"])).toThrow(/Unknown subcommand/);
+  });
+});
+
+describe("runDispatch", () => {
+  it("returns a list payload with BlockKit blocks when text is empty after stripping mentions", async () => {
+    const items: ShoppingItem[] = [{ id: 2, items: "牛乳", disabled: false }];
+    const client = fakeClient({ list: vi.fn(async () => items) });
+
+    const out = await runDispatch("<@U123>", client);
+
+    expect(client.list).toHaveBeenCalledOnce();
+    expect(client.add).not.toHaveBeenCalled();
+    expect(out.kind).toBe("list");
+    if (out.kind === "list") {
+      expect(out.blocks[0]).toMatchObject({ type: "section" });
+    }
+  });
+
+  it("adds newline-split items when text remains after stripping mentions", async () => {
+    const client = fakeClient();
+
+    const out = await runDispatch("<@U123> 牛乳\nパン\n\n  卵 ", client);
+
+    expect(client.add).toHaveBeenCalledWith(["牛乳", "パン", "卵"]);
+    expect(client.list).not.toHaveBeenCalled();
+    expect(out).toEqual({ success: true, kind: "added", count: 3 });
+  });
+});
+
+describe("toUpdateRequests", () => {
+  it("converts a {id: boolean} map to update requests", () => {
+    expect(toUpdateRequests({ "2": true, "3": false, "5": true })).toEqual([
+      { id: 2, checked: true },
+      { id: 3, checked: false },
+      { id: 5, checked: true },
+    ]);
+  });
+
+  it("returns an empty array for an empty map", () => {
+    expect(toUpdateRequests({})).toEqual([]);
+  });
+});
+
+describe("runUpdate", () => {
+  it("forwards converted updates to the GAS client and reports the count", async () => {
+    const client = fakeClient();
+
+    const out = await runUpdate({ "2": true, "3": false }, client);
+
+    expect(client.update).toHaveBeenCalledWith([
+      { id: 2, checked: true },
+      { id: 3, checked: false },
+    ]);
+    expect(out).toEqual({ success: true, updated: 2 });
+  });
+});
+
+describe("runPurge", () => {
+  it("returns the deleted count from the GAS client", async () => {
+    const client = fakeClient({ purge: vi.fn(async () => 4) });
+
+    const out = await runPurge(client);
+
+    expect(client.purge).toHaveBeenCalledOnce();
+    expect(out).toEqual({ success: true, deleted: 4 });
+  });
+});

--- a/test/shopping_list/mention.test.ts
+++ b/test/shopping_list/mention.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { splitItems, stripMentions } from "@/shopping_list/mention.js";
+
+describe("stripMentions", () => {
+  it("removes a single user mention and trims", () => {
+    expect(stripMentions("<@U123> 牛乳")).toBe("牛乳");
+  });
+
+  it("removes multiple mentions anywhere in the text", () => {
+    expect(stripMentions("hi <@U1> and <@U2> please buy milk")).toBe("hi  and  please buy milk");
+  });
+
+  it("returns empty string when only a mention is present", () => {
+    expect(stripMentions("<@U123>")).toBe("");
+  });
+
+  it("returns empty string when only whitespace is present", () => {
+    expect(stripMentions("   \n\t ")).toBe("");
+  });
+
+  it("preserves embedded newlines after trimming", () => {
+    expect(stripMentions("<@U123>\n牛乳\nパン\n")).toBe("牛乳\nパン");
+  });
+});
+
+describe("splitItems", () => {
+  it("splits by newlines and trims each line", () => {
+    expect(splitItems("牛乳\n パン \n卵")).toEqual(["牛乳", "パン", "卵"]);
+  });
+
+  it("removes empty lines", () => {
+    expect(splitItems("牛乳\n\n  \nパン")).toEqual(["牛乳", "パン"]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(splitItems("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Replaces the n8n-side Code/Sheets nodes with a single TS CLI that
calls the existing GAS Web App. Subcommands:

- dispatch <text>: branches on Slack mention text — empty argument
  returns BlockKit blocks for the current list, non-empty appends
  newline-split items to the sheet.
- update: reads a {rowNumber: boolean} state map (from
  slackutils/checkboxes) on stdin and posts updates.
- purge: deletes completed items (cron path).

The list output emits a `blocks` array directly so n8n only needs
to wrap it before passing to the Slack node. Action IDs use the
`checkbox_action_{n}` scheme so slackutils/checkboxes can parse the
interactive payload back.

https://claude.ai/code/session_01KCzJsvwxKW5z26NSympr4u