### PR TITLE
Add Dependabot configuration analysis to repository scanning

### DIFF
--- a/src/ghscan/main.ts
+++ b/src/ghscan/main.ts
@@ -12,6 +12,8 @@ export interface ScanResult {
   pullRequests: PullRequest[];
   outdatedLanguages: string[];
   noActionlint: boolean;
+  noDependabot: boolean;
+  noDependabotCooldown: boolean;
 }
 
 export interface RunOptions {
@@ -78,6 +80,8 @@ export function toScanResult(repo: Repository, latestVersions: ReadonlyMap<strin
     pullRequests: repo.pullRequests,
     outdatedLanguages: detectOutdatedLanguages(repo, latestVersions),
     noActionlint: repo.noActionlint,
+    noDependabot: repo.noDependabot,
+    noDependabotCooldown: repo.noDependabotCooldown,
   };
 }
 
@@ -85,7 +89,12 @@ export function toScanResult(repo: Repository, latestVersions: ReadonlyMap<strin
 
 export function filterScanResults(results: readonly ScanResult[]): ScanResult[] {
   return results.filter(
-    (result) => result.pullRequests.length >= 1 || result.outdatedLanguages.length > 0 || result.noActionlint,
+    (result) =>
+      result.pullRequests.length >= 1 ||
+      result.outdatedLanguages.length > 0 ||
+      result.noActionlint ||
+      result.noDependabot ||
+      result.noDependabotCooldown,
   );
 }
 

--- a/src/github/dependabotParser.ts
+++ b/src/github/dependabotParser.ts
@@ -1,0 +1,62 @@
+import { RequestError } from "@octokit/request-error";
+import type { Octokit } from "@octokit/rest";
+import yaml from "js-yaml";
+
+const DEPENDABOT_PATHS = [".github/dependabot.yml", ".github/dependabot.yaml"] as const;
+
+export interface DependabotAnalysis {
+  noDependabot: boolean;
+  noDependabotCooldown: boolean;
+}
+
+export async function analyzeDependabot(client: Octokit, repoFullName: string): Promise<DependabotAnalysis> {
+  const content = await fetchDependabotFile(client, repoFullName);
+  return analyzeDependabotFile(content);
+}
+
+export function analyzeDependabotFile(content: string | null): DependabotAnalysis {
+  if (content === null) {
+    return { noDependabot: true, noDependabotCooldown: false };
+  }
+  return { noDependabot: false, noDependabotCooldown: !hasCooldownOnAllUpdates(content) };
+}
+
+export async function fetchDependabotFile(client: Octokit, repoFullName: string): Promise<string | null> {
+  const [owner, repo] = repoFullName.split("/");
+  for (const path of DEPENDABOT_PATHS) {
+    try {
+      const { data } = await client.rest.repos.getContent({ owner, repo, path });
+      if (!Array.isArray(data) && "content" in data && data.content) {
+        return Buffer.from(data.content, "base64").toString("utf-8");
+      }
+    } catch (error: unknown) {
+      if (error instanceof RequestError && (error.status === 403 || error.status === 404)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseYaml(content: string): unknown {
+  try {
+    return yaml.load(content);
+  } catch {
+    return null;
+  }
+}
+
+function hasCooldownOnAllUpdates(content: string): boolean {
+  const config = parseYaml(content);
+  if (!isRecord(config)) return false;
+
+  const updates = config.updates;
+  if (!Array.isArray(updates) || updates.length === 0) return false;
+
+  return updates.every((update) => isRecord(update) && isRecord(update.cooldown));
+}

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -10,4 +10,6 @@ export interface Repository {
   pullRequests: PullRequest[];
   languageVersions: Record<string, string[]>;
   noActionlint: boolean;
+  noDependabot: boolean;
+  noDependabotCooldown: boolean;
 }

--- a/src/github/repositoryFetcher.ts
+++ b/src/github/repositoryFetcher.ts
@@ -1,5 +1,6 @@
 import { RequestError } from "@octokit/request-error";
 import type { Octokit } from "@octokit/rest";
+import { analyzeDependabot } from "./dependabotParser.js";
 import type { PullRequest, Repository } from "./repository.js";
 import { analyzeWorkflows } from "./workflowParser.js";
 
@@ -46,9 +47,10 @@ async function buildRepository(
   repo: OctokitRepo,
   labels: readonly string[],
 ): Promise<Repository> {
-  const [pullRequests, workflows] = await Promise.all([
+  const [pullRequests, workflows, dependabot] = await Promise.all([
     fetchPullRequests(client, login, repo.name, labels),
     analyzeWorkflows(client, `${login}/${repo.name}`),
+    analyzeDependabot(client, `${login}/${repo.name}`),
   ]);
 
   return {
@@ -57,6 +59,8 @@ async function buildRepository(
     pullRequests,
     languageVersions: workflows.languageVersions,
     noActionlint: workflows.noActionlint,
+    noDependabot: dependabot.noDependabot,
+    noDependabotCooldown: dependabot.noDependabotCooldown,
   };
 }
 

--- a/test/ghscan/main.test.ts
+++ b/test/ghscan/main.test.ts
@@ -18,6 +18,8 @@ function repo(overrides: Partial<Repository> = {}): Repository {
     pullRequests: [],
     languageVersions: {},
     noActionlint: false,
+    noDependabot: false,
+    noDependabotCooldown: false,
     ...overrides,
   };
 }
@@ -29,6 +31,8 @@ function scanResult(overrides: Partial<ScanResult> = {}): ScanResult {
     pullRequests: [],
     outdatedLanguages: [],
     noActionlint: false,
+    noDependabot: false,
+    noDependabotCooldown: false,
     ...overrides,
   };
 }
@@ -49,6 +53,8 @@ describe("toScanResult", () => {
       pullRequests: [],
       outdatedLanguages: ["ruby"],
       noActionlint: false,
+      noDependabot: false,
+      noDependabotCooldown: false,
     });
   });
 
@@ -96,6 +102,16 @@ describe("filterScanResults", () => {
   it("excludes a result running actionlint with no other flags", () => {
     const results = [scanResult({ name: "with-actionlint" })];
     expect(filterScanResults(results)).toEqual([]);
+  });
+
+  it("includes a result missing dependabot config", () => {
+    const results = [scanResult({ name: "no-dependabot", noDependabot: true })];
+    expect(filterScanResults(results).map((r) => r.name)).toEqual(["no-dependabot"]);
+  });
+
+  it("includes a result missing dependabot cooldown", () => {
+    const results = [scanResult({ name: "no-cooldown", noDependabotCooldown: true })];
+    expect(filterScanResults(results).map((r) => r.name)).toEqual(["no-cooldown"]);
   });
 
   it("returns empty array for empty input", () => {

--- a/test/github/dependabotParser.test.ts
+++ b/test/github/dependabotParser.test.ts
@@ -1,0 +1,128 @@
+import { RequestError } from "@octokit/request-error";
+import dedent from "dedent";
+import { describe, expect, it, vi } from "vitest";
+import { analyzeDependabotFile, fetchDependabotFile } from "@/github/dependabotParser.js";
+
+function encode(content: string): string {
+  return Buffer.from(content).toString("base64");
+}
+
+describe("analyzeDependabotFile", () => {
+  it("flags missing dependabot when content is null", () => {
+    expect(analyzeDependabotFile(null)).toEqual({ noDependabot: true, noDependabotCooldown: false });
+  });
+
+  it("flags missing cooldown when no update has cooldown", () => {
+    const content = dedent`
+      version: 2
+      updates:
+        - package-ecosystem: "npm"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+    `;
+    expect(analyzeDependabotFile(content)).toEqual({ noDependabot: false, noDependabotCooldown: true });
+  });
+
+  it("passes both checks when every update has cooldown", () => {
+    const content = dedent`
+      version: 2
+      updates:
+        - package-ecosystem: "npm"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+          cooldown:
+            default-days: 5
+        - package-ecosystem: "github-actions"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+          cooldown:
+            default-days: 7
+    `;
+    expect(analyzeDependabotFile(content)).toEqual({ noDependabot: false, noDependabotCooldown: false });
+  });
+
+  it("flags missing cooldown when any update is missing cooldown", () => {
+    const content = dedent`
+      version: 2
+      updates:
+        - package-ecosystem: "npm"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+          cooldown:
+            default-days: 5
+        - package-ecosystem: "github-actions"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+    `;
+    expect(analyzeDependabotFile(content)).toEqual({ noDependabot: false, noDependabotCooldown: true });
+  });
+
+  it("flags missing cooldown for empty updates list", () => {
+    const content = dedent`
+      version: 2
+      updates: []
+    `;
+    expect(analyzeDependabotFile(content)).toEqual({ noDependabot: false, noDependabotCooldown: true });
+  });
+
+  it("flags missing cooldown for invalid YAML", () => {
+    expect(analyzeDependabotFile("}{invalid")).toEqual({ noDependabot: false, noDependabotCooldown: true });
+  });
+
+  it("flags missing cooldown when updates is not an array", () => {
+    expect(analyzeDependabotFile("version: 2")).toEqual({ noDependabot: false, noDependabotCooldown: true });
+  });
+});
+
+describe("fetchDependabotFile", () => {
+  function buildClient(getContent: ReturnType<typeof vi.fn>) {
+    return { rest: { repos: { getContent } } } as never;
+  }
+
+  function notFoundError(): RequestError {
+    return new RequestError("Not Found", 404, { request: { method: "GET", url: "", headers: {} } });
+  }
+
+  it("returns null when dependabot file does not exist", async () => {
+    const getContent = vi.fn().mockRejectedValue(notFoundError());
+    const result = await fetchDependabotFile(buildClient(getContent), "testuser/repo1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when access is forbidden", async () => {
+    const getContent = vi
+      .fn()
+      .mockRejectedValue(new RequestError("Forbidden", 403, { request: { method: "GET", url: "", headers: {} } }));
+    const result = await fetchDependabotFile(buildClient(getContent), "testuser/repo1");
+    expect(result).toBeNull();
+  });
+
+  it("fetches and decodes dependabot.yml", async () => {
+    const content = "version: 2\n";
+    const getContent = vi.fn().mockImplementation(({ path }: { path: string }) => {
+      if (path === ".github/dependabot.yml") {
+        return { data: { content: encode(content) } };
+      }
+      throw notFoundError();
+    });
+    const result = await fetchDependabotFile(buildClient(getContent), "testuser/repo1");
+    expect(result).toBe(content);
+  });
+
+  it("falls back to dependabot.yaml when .yml is missing", async () => {
+    const content = "version: 2\n";
+    const getContent = vi.fn().mockImplementation(({ path }: { path: string }) => {
+      if (path === ".github/dependabot.yaml") {
+        return { data: { content: encode(content) } };
+      }
+      throw notFoundError();
+    });
+    const result = await fetchDependabotFile(buildClient(getContent), "testuser/repo1");
+    expect(result).toBe(content);
+  });
+});

--- a/test/github/repositoryFetcher.test.ts
+++ b/test/github/repositoryFetcher.test.ts
@@ -5,7 +5,11 @@ import { fetchRepositories, isActiveRepo } from "@/github/repositoryFetcher.js";
 vi.mock("@/github/workflowParser.js", () => ({
   analyzeWorkflows: vi.fn().mockResolvedValue({ languageVersions: {}, noActionlint: false }),
 }));
+vi.mock("@/github/dependabotParser.js", () => ({
+  analyzeDependabot: vi.fn().mockResolvedValue({ noDependabot: false, noDependabotCooldown: false }),
+}));
 
+import { analyzeDependabot } from "@/github/dependabotParser.js";
 import { analyzeWorkflows } from "@/github/workflowParser.js";
 
 const NOW = Date.now();
@@ -89,6 +93,8 @@ describe("fetchRepositories", () => {
       ],
       languageVersions: {},
       noActionlint: false,
+      noDependabot: false,
+      noDependabotCooldown: false,
     });
     expect(result[1]?.pullRequests).toEqual([
       { title: "Only PR", url: "https://github.com/testuser/repo2/pull/1", labels: [] },
@@ -148,6 +154,18 @@ describe("fetchRepositories", () => {
     await fetchRepositories(client);
 
     expect(analyzeWorkflows).toHaveBeenCalledWith(client, "testuser/repo1");
+  });
+
+  it("passes dependabot analysis results to the repository", async () => {
+    vi.mocked(analyzeDependabot).mockResolvedValueOnce({ noDependabot: false, noDependabotCooldown: true });
+
+    const repos = [fakeRepo({ name: "repo1" })];
+    const client = buildClient({ repos });
+
+    const result = await fetchRepositories(client);
+    expect(result[0]?.noDependabot).toBe(false);
+    expect(result[0]?.noDependabotCooldown).toBe(true);
+    expect(analyzeDependabot).toHaveBeenCalledWith(client, "testuser/repo1");
   });
 
   it("includes PR labels in the result", async () => {


### PR DESCRIPTION
## Summary
This PR adds support for analyzing Dependabot configuration files in repositories. It detects whether a repository has a Dependabot configuration and validates that all dependency updates include cooldown settings.

## Key Changes
- **New `dependabotParser` module** (`src/github/dependabotParser.ts`):
  - `fetchDependabotFile()`: Fetches Dependabot configuration from `.github/dependabot.yml` or `.github/dependabot.yaml`
  - `analyzeDependabotFile()`: Parses YAML and checks if all updates have cooldown settings
  - `analyzeDependabot()`: Orchestrates fetching and analyzing in one call
  - Gracefully handles missing files, invalid YAML, and API errors

- **Updated `Repository` interface** to include:
  - `noDependabot`: Flag indicating missing Dependabot configuration
  - `noDependabotCooldown`: Flag indicating missing cooldown on any update

- **Updated `repositoryFetcher`** to call `analyzeDependabot()` and populate the new fields

- **Updated `ScanResult` interface** to include the same Dependabot flags

- **Updated filtering logic** in `filterScanResults()` to include repositories with missing Dependabot configuration or cooldown settings

- **Comprehensive test coverage** for both the parser and integration with repository fetching

## Implementation Details
- The parser tries `.github/dependabot.yml` first, then falls back to `.github/dependabot.yaml`
- Returns `null` for 404 and 403 errors (file not found or forbidden access)
- Uses `js-yaml` for YAML parsing with error handling for malformed files
- Validates that all updates in the configuration have a `cooldown` object with settings
- Empty update lists are treated as missing cooldown configuration

https://claude.ai/code/session_01FNAE7eDpTXrhQSMfctSSD5