### PR TITLE
Add Google Apps Script URL configuration for shopping list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ X_BEARER_TOKEN=your_bearer_token_here
 XFETCH_STATE_FILE=/path/to/xfetch_state.json
 TRAFFICNEWS_STATE_FILE=/path/to/trafficnews_state.json
 MICHINOEKI_STATE_FILE=/path/to/michinoeki_state.json
+SHOPPING_LIST_GAS_URL=https://script.google.com/macros/s/your_script_id/exec


### PR DESCRIPTION
## Summary
Added a new environment variable configuration for the shopping list Google Apps Script integration.

## Changes
- Added `SHOPPING_LIST_GAS_URL` environment variable to `.env.example` to support Google Apps Script webhook integration for shopping list functionality

## Details
This configuration variable allows the application to communicate with a Google Apps Script macro endpoint, enabling integration with a shopping list service. Users will need to provide their own Google Apps Script deployment URL in the format `https://script.google.com/macros/s/{script_id}/exec`.

https://claude.ai/code/session_01UPknLpmfhHJCmNCqrVRGEM