### PR TITLE
Return matched/skipped counts from update operations

### DIFF
--- a/gas/shopping_list/src/main.ts
+++ b/gas/shopping_list/src/main.ts
@@ -31,9 +31,10 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
       case "add":
         addItems(body.items);
         return jsonOutput({ success: true });
-      case "update":
-        updateCheckedState(body.updates);
-        return jsonOutput({ success: true });
+      case "update": {
+        const result = updateCheckedState(body.updates);
+        return jsonOutput<UpdateResult>({ success: true, data: result });
+      }
       case "purge": {
         const deleted = purgeCompletedItems();
         return jsonOutput<{ deleted: number }>({ success: true, data: { deleted } });

--- a/gas/shopping_list/src/spreadsheet.ts
+++ b/gas/shopping_list/src/spreadsheet.ts
@@ -48,14 +48,21 @@ function addItems(items: string[]): void {
   }
 }
 
-function updateCheckedState(updates: UpdateRequest[]): void {
+function updateCheckedState(updates: UpdateRequest[]): UpdateResult {
   const sheet = getSheet();
   const rows = loadShoppingList(sheet);
+  let matched = 0;
+  const skipped: string[] = [];
   updates.forEach(({ id, checked }) => {
     const row = rows.find(r => r.id === id);
-    if (!row) return;
+    if (!row) {
+      skipped.push(id);
+      return;
+    }
     sheet.getRange(row.rowNumber, COL_DISABLED).setValue(checked ? 'true' : '');
+    matched++;
   });
+  return { matched, skipped };
 }
 
 function purgeCompletedItems(): number {

--- a/gas/shopping_list/src/types.ts
+++ b/gas/shopping_list/src/types.ts
@@ -9,6 +9,11 @@ interface UpdateRequest {
   checked: boolean;
 }
 
+interface UpdateResult {
+  matched: number;
+  skipped: string[];
+}
+
 interface ApiResponse<T = undefined> {
   success: boolean;
   data?: T;

--- a/src/shopping_list/gas.ts
+++ b/src/shopping_list/gas.ts
@@ -9,6 +9,11 @@ export interface UpdateRequest {
   checked: boolean;
 }
 
+export interface UpdateResult {
+  matched: number;
+  skipped: string[];
+}
+
 interface GasResponse<T> {
   success: boolean;
   data?: T;
@@ -18,7 +23,7 @@ interface GasResponse<T> {
 export interface GasClientApi {
   list(): Promise<ShoppingItem[]>;
   add(items: string[]): Promise<void>;
-  update(updates: UpdateRequest[]): Promise<void>;
+  update(updates: UpdateRequest[]): Promise<UpdateResult>;
   purge(): Promise<number>;
 }
 
@@ -47,8 +52,9 @@ export class GasClient implements GasClientApi {
     await this.post({ action: "add", items });
   }
 
-  async update(updates: UpdateRequest[]): Promise<void> {
-    await this.post({ action: "update", updates });
+  async update(updates: UpdateRequest[]): Promise<UpdateResult> {
+    const data = await this.post<UpdateResult>({ action: "update", updates });
+    return data ?? { matched: 0, skipped: [] };
   }
 
   async purge(): Promise<number> {

--- a/src/shopping_list/main.ts
+++ b/src/shopping_list/main.ts
@@ -24,7 +24,8 @@ export type DispatchOutput = DispatchListOutput | DispatchAddOutput;
 
 export interface UpdateOutput {
   success: true;
-  updated: number;
+  matched: number;
+  skipped: string[];
 }
 
 export interface PurgeOutput {
@@ -97,8 +98,8 @@ export function toUpdateRequests(stateMap: Record<string, boolean>) {
 
 export async function runUpdate(stateMap: Record<string, boolean>, client: GasClientApi): Promise<UpdateOutput> {
   const updates = toUpdateRequests(stateMap);
-  await client.update(updates);
-  return { success: true, updated: updates.length };
+  const result = await client.update(updates);
+  return { success: true, ...result };
 }
 
 export async function runPurge(client: GasClientApi): Promise<PurgeOutput> {

--- a/test/shopping_list/main.test.ts
+++ b/test/shopping_list/main.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GasClientApi, ShoppingItem, UpdateRequest } from "@/shopping_list/gas.js";
+import type { GasClientApi, ShoppingItem, UpdateRequest, UpdateResult } from "@/shopping_list/gas.js";
 import {
   extractTextFromSlackEvents,
   parseArgs,
@@ -13,7 +13,7 @@ function fakeClient(overrides: Partial<GasClientApi> = {}): GasClientApi {
   return {
     list: vi.fn(async () => [] as ShoppingItem[]),
     add: vi.fn(async (_items: string[]) => {}),
-    update: vi.fn(async (_updates: UpdateRequest[]) => {}),
+    update: vi.fn(async (_updates: UpdateRequest[]): Promise<UpdateResult> => ({ matched: 0, skipped: [] })),
     purge: vi.fn(async () => 0),
     ...overrides,
   };
@@ -112,8 +112,10 @@ describe("toUpdateRequests", () => {
 });
 
 describe("runUpdate", () => {
-  it("forwards converted updates to the GAS client and reports the count", async () => {
-    const client = fakeClient();
+  it("forwards converted updates to the GAS client and surfaces the matched/skipped counts", async () => {
+    const client = fakeClient({
+      update: vi.fn(async (): Promise<UpdateResult> => ({ matched: 1, skipped: ["uuid-b"] })),
+    });
 
     const out = await runUpdate({ "uuid-a": true, "uuid-b": false }, client);
 
@@ -121,7 +123,7 @@ describe("runUpdate", () => {
       { id: "uuid-a", checked: true },
       { id: "uuid-b", checked: false },
     ]);
-    expect(out).toEqual({ success: true, updated: 2 });
+    expect(out).toEqual({ success: true, matched: 1, skipped: ["uuid-b"] });
   });
 });
 


### PR DESCRIPTION
## Summary
Enhanced the update operation to provide detailed feedback about which items were successfully matched and updated versus which ones were skipped due to not being found.

## Key Changes
- Added `UpdateResult` interface to track `matched` count and `skipped` item IDs
- Updated `GasClient.update()` to return `UpdateResult` instead of `void`
- Modified `updateCheckedState()` in the Google Apps Script backend to track and return matched/skipped results
- Updated `runUpdate()` to surface the detailed results instead of just the total count
- Changed `UpdateOutput` interface to include `matched` and `skipped` fields instead of `updated`

## Implementation Details
- The backend now iterates through update requests and tracks which IDs were found in the spreadsheet (matched) and which were not (skipped)
- If an update request references a non-existent item ID, it's added to the skipped array rather than silently ignored
- The client-side `update()` method safely handles cases where the server doesn't return data by defaulting to `{ matched: 0, skipped: [] }`
- All type definitions across the codebase (TypeScript client and Google Apps Script) have been synchronized with the new interface

https://claude.ai/code/session_01AgWcbzLAvjjgQhqYzNPJ41