### PR TITLE
Add cooldown settings to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,13 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary

- Adds `cooldown` block to each ecosystem entry in `.github/dependabot.yml`
- Prevents Dependabot from opening PRs until a release has had time to stabilize

## Cooldown

Adds a 3-day cooldown for all version types (`default-days: 3`).

## Motivation

Fresh releases occasionally contain regressions or are quickly superseded by
a follow-up patch. A 3-day cooldown gives the community time to surface
issues before a PR is opened here, reducing noise without meaningfully delaying
dependency updates.