### PR TITLE
Skip dependabot analysis for repos without workflows

### DIFF
--- a/src/github/repositoryFetcher.ts
+++ b/src/github/repositoryFetcher.ts
@@ -47,11 +47,14 @@ async function buildRepository(
   repo: OctokitRepo,
   labels: readonly string[],
 ): Promise<Repository> {
-  const [pullRequests, workflows, dependabot] = await Promise.all([
+  const repoFullName = `${login}/${repo.name}`;
+  const [pullRequests, workflows] = await Promise.all([
     fetchPullRequests(client, login, repo.name, labels),
-    analyzeWorkflows(client, `${login}/${repo.name}`),
-    analyzeDependabot(client, `${login}/${repo.name}`),
+    analyzeWorkflows(client, repoFullName),
   ]);
+  const dependabot = workflows.hasWorkflows
+    ? await analyzeDependabot(client, repoFullName)
+    : { noDependabot: false, noDependabotCooldown: false };
 
   return {
     name: repo.name,

--- a/src/github/workflowParser.ts
+++ b/src/github/workflowParser.ts
@@ -11,6 +11,7 @@ const LANGUAGE_KEYS = {
 const MATRIX_REF_PATTERN = /^\$\{\{\s*matrix\.([\w-]+)\s*\}\}$/;
 
 export interface WorkflowAnalysis {
+  hasWorkflows: boolean;
   languageVersions: Record<string, string[]>;
   noActionlint: boolean;
 }
@@ -22,6 +23,7 @@ export async function analyzeWorkflows(client: Octokit, repoFullName: string): P
 
 export function analyzeWorkflowFiles(files: string[]): WorkflowAnalysis {
   return {
+    hasWorkflows: files.length > 0,
     languageVersions: extractAllLanguageVersions(files),
     noActionlint: files.length > 0 && files.every((f) => !/\bactionlint\b/.test(f)),
   };

--- a/test/github/repositoryFetcher.test.ts
+++ b/test/github/repositoryFetcher.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { fetchRepositories, isActiveRepo } from "@/github/repositoryFetcher.js";
 
 vi.mock("@/github/workflowParser.js", () => ({
-  analyzeWorkflows: vi.fn().mockResolvedValue({ languageVersions: {}, noActionlint: false }),
+  analyzeWorkflows: vi.fn().mockResolvedValue({ hasWorkflows: true, languageVersions: {}, noActionlint: false }),
 }));
 vi.mock("@/github/dependabotParser.js", () => ({
   analyzeDependabot: vi.fn().mockResolvedValue({ noDependabot: false, noDependabotCooldown: false }),
@@ -123,6 +123,7 @@ describe("fetchRepositories", () => {
 
   it("passes language versions from workflow analysis", async () => {
     vi.mocked(analyzeWorkflows).mockResolvedValueOnce({
+      hasWorkflows: true,
       languageVersions: { ruby: ["3.1", "3.2"] },
       noActionlint: false,
     });
@@ -132,6 +133,23 @@ describe("fetchRepositories", () => {
 
     const result = await fetchRepositories(client);
     expect(result[0]?.languageVersions).toEqual({ ruby: ["3.1", "3.2"] });
+  });
+
+  it("skips dependabot analysis when the repo has no workflows", async () => {
+    vi.mocked(analyzeWorkflows).mockResolvedValueOnce({
+      hasWorkflows: false,
+      languageVersions: {},
+      noActionlint: false,
+    });
+    vi.mocked(analyzeDependabot).mockClear();
+
+    const repos = [fakeRepo({ name: "data-only" })];
+    const client = buildClient({ repos });
+
+    const result = await fetchRepositories(client);
+    expect(analyzeDependabot).not.toHaveBeenCalled();
+    expect(result[0]?.noDependabot).toBe(false);
+    expect(result[0]?.noDependabotCooldown).toBe(false);
   });
 
   it("returns empty pull request list when access is forbidden (403)", async () => {

--- a/test/github/workflowParser.test.ts
+++ b/test/github/workflowParser.test.ts
@@ -8,6 +8,16 @@ function encode(content: string): string {
 }
 
 describe("analyzeWorkflowFiles", () => {
+  describe("hasWorkflows", () => {
+    it("returns false when no workflow files exist", () => {
+      expect(analyzeWorkflowFiles([]).hasWorkflows).toBe(false);
+    });
+
+    it("returns true when at least one workflow file exists", () => {
+      expect(analyzeWorkflowFiles(["name: CI"]).hasWorkflows).toBe(true);
+    });
+  });
+
   describe("noActionlint", () => {
     it("returns false when no workflow files exist", () => {
       expect(analyzeWorkflowFiles([]).noActionlint).toBe(false);


### PR DESCRIPTION
## Summary
This PR optimizes the repository analysis process by skipping dependabot analysis for repositories that don't have any GitHub Actions workflows. This reduces unnecessary API calls and improves performance for data-only repositories.

## Key Changes
- Added `hasWorkflows` field to the `WorkflowAnalysis` interface to track whether a repository contains any workflow files
- Modified `buildRepository()` to conditionally call `analyzeDependabot()` only when workflows exist
- When no workflows are present, dependabot analysis is skipped and default values (`noDependabot: false`, `noDependabotCooldown: false`) are used
- Updated all test mocks and test cases to include the new `hasWorkflows` field

## Implementation Details
- The `analyzeWorkflowFiles()` function now returns `hasWorkflows: files.length > 0`
- Dependabot analysis is now awaited separately after workflow analysis completes, allowing the conditional logic to determine if it should be called
- This change maintains backward compatibility by using sensible defaults when dependabot analysis is skipped

https://claude.ai/code/session_018WXwXA6K5YawvWMF1rTDVF