### PR TITLE
Refactor auto-merge workflow to use label-based triggering

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,27 +1,20 @@
 name: Auto merge Pull Requests
-on: pull_request
+on:
+  pull_request:
+    types: [labeled]
 
 jobs:
-  dependabot:
+  auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'tk0miya/n8n_tools'
+    if: github.event.label.name == 'auto-merge'
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
-          gh pr edit "$PR_URL" --add-label "auto-merge"
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,0 +1,26 @@
+name: Add auto-merge label to Dependabot PRs
+on: pull_request
+
+jobs:
+  add-auto-merge-label:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add auto-merge label
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr edit "$PR_URL" --add-label "auto-merge"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replaced the bot-specific `auto-merge.yml` with a unified label-based approach
- Added `dependabot-auto-label.yml` to handle adding the `auto-merge` label to eligible Dependabot PRs
- The new workflow triggers on the `auto-merge` label instead of checking the PR author

## Test plan
- [ ] Verify Dependabot PRs for minor/patch updates get the `auto-merge` label applied automatically
- [ ] Verify labeled PRs are approved and merged automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)