### PR TITLE
Migrate tsconfig from Node16 to NodeNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Migrate `module` and `moduleResolution` from `Node16` to `NodeNext` in tsconfig.json
- `Node16` is deprecated in TypeScript 6.0; `NodeNext` is the recommended replacement and is functionally equivalent

## Migration notes

`Node16` and `NodeNext` are aliases that track the same behavior today, but `Node16` is deprecated in TypeScript 6.0 and will be removed in 7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)