### PR TITLE
ci: Replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
       - name: Approve a PR
         run: |

--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
+          client-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
           private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary

- Replace deprecated `app-id` input with `client-id` in `actions/create-github-app-token@v3`
- Since v3.1.0, `app-id` has been deprecated in favor of `client-id`
- This change affects `auto-merge.yml`, `dependabot-auto-label.yml`, and `biome-migrate.yml`