### PR TITLE
fix(ghscan): use nodejs/Release schedule.json for Node LTS detection

### DIFF
--- a/src/github/languageVersionFetcher.ts
+++ b/src/github/languageVersionFetcher.ts
@@ -10,18 +10,23 @@ const LANGUAGE_RELEASE_REPOS: ReadonlyMap<string, string> = new Map([
 
 const STABLE_TAG_RE = /^v?\d+\.\d+[._]\d+$/;
 
-/** Languages where only even-numbered major versions count as stable (LTS). */
-const LTS_EVEN_MAJOR_LANGUAGES: ReadonlySet<string> = new Set(["node"]);
-
 export async function fetchLatestLanguageVersions(client: Octokit): Promise<Map<string, VersionTuple>> {
   const entries = await Promise.all(
     [...LANGUAGE_RELEASE_REPOS].map(async ([lang, repo]) => {
-      const ltsOnly = LTS_EVEN_MAJOR_LANGUAGES.has(lang);
-      const tag = ltsOnly ? await fetchLatestLtsTag(client, repo) : await fetchLatestReleaseTag(client, repo);
-      return [lang, parseTagToVersion(tag)] as const;
+      const version = await fetchLatestVersion(client, lang, repo);
+      return [lang, version] as const;
     }),
   );
   return new Map(entries);
+}
+
+async function fetchLatestVersion(client: Octokit, lang: string, repo: string): Promise<VersionTuple> {
+  switch (lang) {
+    case "node":
+      return fetchLatestNodeLtsVersion(client);
+    default:
+      return parseTagToVersion(await fetchLatestReleaseTag(client, repo));
+  }
 }
 
 function splitRepo(fullName: string): { owner: string; repo: string } {
@@ -42,16 +47,29 @@ async function fetchLatestReleaseTag(client: Octokit, repoFullName: string): Pro
   }
 }
 
-async function fetchLatestLtsTag(client: Octokit, repoFullName: string): Promise<string> {
-  const { owner, repo } = splitRepo(repoFullName);
-  const { data: tags } = await client.rest.repos.listTags({ owner, repo, per_page: 100 });
-  const lts = tags.find((t) => {
-    if (!STABLE_TAG_RE.test(t.name)) return false;
-    const major = Number(t.name.replace(/^v/, "").split(/[._]/)[0]);
-    return major % 2 === 0;
+async function fetchLatestNodeLtsVersion(client: Octokit): Promise<VersionTuple> {
+  const { data } = await client.rest.repos.getContent({
+    owner: "nodejs",
+    repo: "Release",
+    path: "schedule.json",
   });
-  if (!lts) throw new Error(`No LTS release found for ${repoFullName}`);
-  return lts.name;
+  if (Array.isArray(data) || !("content" in data) || !data.content) {
+    throw new Error("Failed to fetch nodejs/Release schedule.json");
+  }
+  const json = JSON.parse(Buffer.from(data.content, "base64").toString("utf-8")) as Record<string, unknown>;
+  const today = new Date();
+  let maxMajor = -1;
+  for (const [key, entry] of Object.entries(json)) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const { lts, end } = entry as { lts?: string; end?: string };
+    if (!lts || !end) continue;
+    if (new Date(lts) <= today && today < new Date(end)) {
+      const major = Number(key.replace(/^v/, ""));
+      if (Number.isFinite(major) && major > maxMajor) maxMajor = major;
+    }
+  }
+  if (maxMajor < 0) throw new Error("No active Node.js LTS major found");
+  return [maxMajor, 99];
 }
 
 function parseTagToVersion(tag: string): VersionTuple {

--- a/test/github/languageVersionFetcher.test.ts
+++ b/test/github/languageVersionFetcher.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchLatestLanguageVersions } from "@/github/languageVersionFetcher.js";
+
+interface ScheduleEntry {
+  start?: string;
+  lts?: string;
+  maintenance?: string;
+  end?: string;
+}
+
+const DEFAULT_SCHEDULE: Record<string, ScheduleEntry> = {
+  v22: { start: "2024-04-24", lts: "2024-10-29", end: "2027-04-30" },
+  v24: { start: "2025-05-06", lts: "2025-10-28", end: "2028-04-30" },
+  v26: { start: "2026-04-22", lts: "2026-10-28", end: "2029-04-30" },
+};
 
 function buildClient({
   latestRelease = {} as Record<string, string>,
   tags = {} as Record<string, { name: string }[]>,
+  schedule = DEFAULT_SCHEDULE,
 } = {}) {
   return {
     rest: {
@@ -19,27 +33,42 @@ function buildClient({
           const fullName = `${owner}/${name}`;
           return { data: tags[fullName] ?? [] };
         }),
+        getContent: vi
+          .fn()
+          .mockImplementation(({ owner, repo, path }: { owner: string; repo: string; path: string }) => {
+            if (owner === "nodejs" && repo === "Release" && path === "schedule.json") {
+              const content = Buffer.from(JSON.stringify(schedule)).toString("base64");
+              return { data: { content, type: "file" } };
+            }
+            throw new Error("Not Found");
+          }),
       },
     },
   } as never;
 }
 
 describe("fetchLatestLanguageVersions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-06T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns the latest major.minor version for each language", async () => {
     const client = buildClient({
       latestRelease: {
         "ruby/ruby": "v4_0_2",
         "python/cpython": "v3.13.3",
       },
-      tags: {
-        "nodejs/node": [{ name: "v25.9.0" }, { name: "v24.14.1" }, { name: "v22.14.0" }],
-      },
     });
     const result = await fetchLatestLanguageVersions(client);
     expect(result).toEqual(
       new Map([
         ["ruby", [4, 0]],
-        ["node", [24, 14]],
+        ["node", [24, 99]],
         ["python", [3, 13]],
       ]),
     );
@@ -51,7 +80,6 @@ describe("fetchLatestLanguageVersions", () => {
         "ruby/ruby": "v4_0_2",
       },
       tags: {
-        "nodejs/node": [{ name: "v24.14.1" }],
         "python/cpython": [{ name: "v3.15.0a7" }, { name: "v3.14.1" }, { name: "v3.13.3" }],
       },
     });
@@ -59,18 +87,27 @@ describe("fetchLatestLanguageVersions", () => {
     expect(result.get("python")).toEqual([3, 14]);
   });
 
-  it("picks the latest even-major tag for Node.js (LTS)", async () => {
+  it("ignores Node.js majors that have not yet entered LTS", async () => {
     const client = buildClient({
       latestRelease: {
         "ruby/ruby": "v4_0_2",
         "python/cpython": "v3.13.3",
       },
-      tags: {
-        "nodejs/node": [{ name: "v25.9.0" }, { name: "v25.8.0" }, { name: "v24.14.1" }, { name: "v22.14.0" }],
+    });
+    const result = await fetchLatestLanguageVersions(client);
+    expect(result.get("node")).toEqual([24, 99]);
+  });
+
+  it("picks the new Node.js LTS once its lts date has passed", async () => {
+    vi.setSystemTime(new Date("2026-11-01T00:00:00Z"));
+    const client = buildClient({
+      latestRelease: {
+        "ruby/ruby": "v4_0_2",
+        "python/cpython": "v3.13.3",
       },
     });
     const result = await fetchLatestLanguageVersions(client);
-    expect(result.get("node")).toEqual([24, 14]);
+    expect(result.get("node")).toEqual([26, 99]);
   });
 
   it("throws when a repo has no stable tags", async () => {
@@ -79,7 +116,6 @@ describe("fetchLatestLanguageVersions", () => {
         "ruby/ruby": "v4_0_2",
       },
       tags: {
-        "nodejs/node": [{ name: "v24.14.1" }],
         "python/cpython": [{ name: "v3.15.0a7" }],
       },
     });


### PR DESCRIPTION
The previous heuristic flagged any even-major Node tag as the latest LTS, which produces false positives in the ~6 months between a new even-major release and its actual LTS promotion (e.g. Node 26 in 2026-04 ~ 2026-10). Switch to consulting nodejs/Release schedule.json and accept only majors whose lts date has passed and end date has not.