### PR TITLE
chore: set persist-credentials: false in actions/checkout

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Run actionlint
       shell: bash
       run: |

--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-gas-shopping-list.yml
+++ b/.github/workflows/deploy-gas-shopping-list.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
## Summary

Set `persist-credentials: false` on every `actions/checkout` step to prevent the GitHub token from being written to a file under `$RUNNER_TEMP`, where it can be read (and base64-decoded) by any subsequent step.

The token-bearing config file is the default behavior of `actions/checkout`, and a compromised action or a script-injection bug elsewhere in the workflow can lift the token out of it. Turning credential persistence off removes that attack surface for the workflows that don't need to push back to the repo.

For `biome-migrate.yml`, the `token:` input on `actions/checkout` was unnecessary — `peter-evans/create-pull-request` already authenticates with the GitHub App token directly, so dropping it in favor of `persist-credentials: false` doesn't change behavior.

Reference: https://zenn.dev/kou_pg_0131/articles/gha-checkout-persist-credentials

## Test plan

- [x] `actionlint` passes
- [ ] Verify CI on this PR still runs to completion