### PR TITLE
ci: scope GitHub App token to minimum required permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Approve a PR
         run: |
           gh pr review --approve "$PR_URL"

--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
           private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
+          permission-issues: write
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3


### PR DESCRIPTION
## Summary

Pass explicit `permission-*` inputs to `actions/create-github-app-token` so that the issued installation token only carries the permissions each workflow actually uses, instead of inheriting the full installation permission set.

This addresses the `github-app` finding from `zizmor`: by default, omitting `permission-*` inputs makes `create-github-app-token` issue a token with the App's full installation permissions, which is broader than any single workflow needs.

### Per-workflow scopes

| File | API surface used | Permissions granted |
|---|---|---|
| `auto-merge.yml` | `gh pr review --approve` + `gh pr merge --auto --merge` | `contents: write`, `pull-requests: write` |
| `dependabot-auto-label.yml` | `gh pr edit --add-label` (Issues labels API) | `issues: write` |
| `biome-migrate.yml` | `peter-evans/create-pull-request` (branch push, PR creation, labels) | `contents: write`, `pull-requests: write`, `issues: write` |

The `issues: write` scopes are needed because GitHub treats PR labels as Issue labels (`POST /repos/.../issues/.../labels`).

## Test plan

- [x] `actionlint` passes
- [ ] Auto-merge of this PR exercises the new `auto-merge.yml` scopes
- [ ] Next Dependabot PR will exercise the new `dependabot-auto-label.yml` scopes
- [ ] Next `biome-migrate.yml` run will exercise the `peter-evans/create-pull-request` scopes