### PR TITLE
ci: extend Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
     cooldown:
-      default-days: 3
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
       timezone: "Asia/Tokyo"
     cooldown:
-      default-days: 3
+      default-days: 7
     ignore:
       # Hold Node.js releases until LTS promotion (October each year).
       # Remove an entry when it enters LTS; add the next April release as it approaches.


### PR DESCRIPTION
## Summary

Bump `cooldown.default-days` in `.github/dependabot.yml` from `3` to `7` for every ecosystem block.

This addresses the `dependabot-cooldown` finding from `zizmor`, which flags anything below 7 days as "insufficient cooldown" — the rationale being that newly released package versions often have post-release issues (broken builds, regressions, malicious typosquats) discovered in the first few days, so giving them a week to settle before Dependabot auto-bumps reduces the chance of pulling in something compromised.

## Test plan

- [x] `actionlint` is unaffected (no workflow change)
- [ ] Next Dependabot cycle will respect the new 7-day cooldown