### PR TITLE
ci: add zizmor and rename actionlint workflow to workflow-lint

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,4 +1,4 @@
-name: actionlint
+name: Workflow lint
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  actionlint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -22,3 +22,13 @@ jobs:
       run: |
         bash <(curl -L https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         ./actionlint -color
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        advanced-security: false


### PR DESCRIPTION
## Summary

Adopt the `zizmor` GitHub Actions security linter as a CI check, alongside the existing `actionlint` runner.

- Rename `.github/workflows/actionlint.yml` to `.github/workflows/workflow-lint.yml`.
- Within the renamed workflow, run `actionlint` and `zizmor` as two parallel jobs so a finding in either tool fails the workflow without blocking the other.
- Use `zizmorcore/zizmor-action` pinned to the `v0.5.6` SHA, matching the policy applied to all other actions in this repo.

`zizmor` complements `actionlint` (syntax / typo / shellcheck) by auditing GitHub Actions workflows for security-relevant issues such as `excessive-permissions`, `cache-poisoning`, `unpinned-uses`, `template-injection`, etc.

References:
- https://docs.zizmor.sh/
- https://github.com/zizmorcore/zizmor-action

## Test plan

- [x] Verify both `actionlint` and `zizmor` jobs run and pass on this PR.