### PR TITLE
ci: fix zizmor ref-version-mismatch for actions/checkout pins

### DIFF
--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -22,7 +22,7 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy-gas-shopping-list.yml
+++ b/.github/workflows/deploy-gas-shopping-list.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -14,7 +14,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Run actionlint
@@ -26,7 +26,7 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## 背景

先日追加した zizmor ジョブ（`.github/workflows/workflow-lint.yml`）が、既存ワークフローの `actions/checkout` ピンに対して `ref-version-mismatch` を検出し、すべての PR で CI が失敗する状態になっていました（例: #167 の zizmor ジョブ）。

## 原因

```
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
```

ピン留めしている SHA `de0fac2e` は実際にはタグ `v6.0.2` のコミットを指していますが、コメントの `# v6`（フローティングなメジャータグ）は現在より新しいコミットを指しているため、zizmor が「コメントと実際にピンしている版の不一致」として High confidence で警告していました（medium × 5件 → exit 13）。

## 変更内容

5箇所すべてのコメントを、実際にピン留めしている版 `# v6.0.2` に揃えました（zizmor の auto-fix 推奨どおり）。SHA は変更していません。

- `ci.yml`
- `biome-migrate.yml`
- `deploy-gas-shopping-list.yml`
- `workflow-lint.yml` （2箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)