### PR TITLE
ci: drop unnecessary issues permission from biome migrate token

### DIFF
--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -20,7 +20,6 @@ jobs:
           private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Problem

The "Biome migrate" workflow fails at the `actions/create-github-app-token` step with a 422: `The permissions requested are not granted to this installation.`

## Root cause

The token explicitly requested `permission-issues: write`, but labeling a pull request only requires the **Pull requests** permission, not **Issues**. The Repo Housekeeper app installation was never granted Issues, so requesting it made token creation exceed the installation's permissions and fail before the workflow could run.

## Fix

Drop `permission-issues: write`, leaving `contents: write` + `pull-requests: write` — the actual minimum for opening and labeling a PR.

Verified on tk0miya/rubocop-herb#164: the token step and PR labeling both succeed without the Issues permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)