### PR TITLE
Upgrade js-yaml to v5 and update import syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,11 @@
         "@octokit/rest": "^22.0.1",
         "castv2-client": "^1.2.0",
         "dotenv": "^17.4.2",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^5.1.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
         "@types/dedent": "^0.7.2",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
         "dedent": "^1.7.2",
         "playwright": "^1.61.1",
@@ -94,9 +93,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -114,9 +110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -134,9 +127,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -154,9 +144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1024,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1044,9 +1028,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,9 +1045,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1084,9 +1062,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,9 +1079,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,9 +1096,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,13 +1229,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1639,9 +1601,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",
@@ -1657,7 +1619,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-with-bigint": {
@@ -1809,9 +1771,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1833,9 +1792,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1857,9 +1813,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1881,9 +1834,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@octokit/rest": "^22.0.1",
     "castv2-client": "^1.2.0",
     "dotenv": "^17.4.2",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^5.1.0"
   },
   "overrides": {
     "protobufjs": "^7.5.5"
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@types/dedent": "^0.7.2",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
     "dedent": "^1.7.2",
     "playwright": "^1.61.1",

--- a/src/github/dependabotParser.ts
+++ b/src/github/dependabotParser.ts
@@ -1,6 +1,6 @@
 import { RequestError } from "@octokit/request-error";
 import type { Octokit } from "@octokit/rest";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const DEPENDABOT_PATHS = [".github/dependabot.yml", ".github/dependabot.yaml"] as const;
 

--- a/src/github/workflowParser.ts
+++ b/src/github/workflowParser.ts
@@ -1,6 +1,6 @@
 import { RequestError } from "@octokit/request-error";
 import type { Octokit } from "@octokit/rest";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const LANGUAGE_KEYS = {
   "ruby-version": "ruby",


### PR DESCRIPTION
## Summary
Upgrade the `js-yaml` dependency from v4 to v5 and update the import statements to use named imports instead of default imports to maintain compatibility with the new version.

## Key Changes
- Updated `js-yaml` dependency from `^4.2.0` to `^5.1.0` in package.json
- Removed `@types/js-yaml` from devDependencies (no longer needed with js-yaml v5)
- Changed import statements in `src/github/dependabotParser.ts` and `src/github/workflowParser.ts` from default imports (`import yaml from "js-yaml"`) to named imports (`import * as yaml from "js-yaml"`)

## Implementation Details
The js-yaml v5 release changed its export structure, requiring the import syntax to be updated from a default export to a namespace import. This change ensures the code remains compatible with the newer version while maintaining the same API usage throughout the codebase.

https://claude.ai/code/session_01HzXLqgoRPjtaa6Prp1Z2WA