### PR TITLE
ci: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_CLIENT_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
+          client-id: ${{ vars.REPO_HOUSEKEEPER_CLIENT_ID }}
           private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
+          client-id: ${{ vars.PR_AUTO_MERGER_CLIENT_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
           permission-pull-requests: write
       - name: Dependabot metadata


### PR DESCRIPTION
`actions/create-github-app-token` v3.1.0 deprecated the `app-id` input in favor of `client-id`.

This switches the workflow inputs to `client-id` and references the new `PR_AUTO_MERGER_CLIENT_ID` / `REPO_HOUSEKEEPER_CLIENT_ID` repository variables (already configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)