### PR TITLE
Update GitHub Actions workflow version comments

### DIFF
--- a/.github/workflows/biome-migrate.yml
+++ b/.github/workflows/biome-migrate.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "npm"
@@ -38,7 +38,7 @@ jobs:
         run: npx biome migrate --write
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: chore/biome-migrate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -17,7 +17,7 @@ jobs:
           permission-pull-requests: write
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add auto-merge label

--- a/.github/workflows/deploy-gas-shopping-list.yml
+++ b/.github/workflows/deploy-gas-shopping-list.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - name: Install dependencies


### PR DESCRIPTION
## Summary
This PR updates the version comments in GitHub Actions workflow files to reflect the actual semantic versions of the actions being used. The commit hashes remain unchanged, ensuring no functional modifications to the workflows.

## Changes
- Updated `actions/setup-node` version comment from `v6` to `v6.4.0` in:
  - `.github/workflows/biome-migrate.yml`
  - `.github/workflows/ci.yml`
  - `.github/workflows/deploy-gas-shopping-list.yml`
- Updated `peter-evans/create-pull-request` version comment from `v8` to `v8.1.1` in `.github/workflows/biome-migrate.yml`
- Updated `dependabot/fetch-metadata` version comment from `v3` to `v3.1.0` in `.github/workflows/dependabot-auto-label.yml`

## Details
These changes improve documentation accuracy by pinning version comments to the exact semantic versions corresponding to the commit hashes already specified in the workflows. This makes it easier for developers to understand which versions are in use without needing to cross-reference commit hashes with release tags.

https://claude.ai/code/session_01S1WThqHGQMb74usWQfsJ5b