### PR TITLE
Allow RemoteTrigger permission by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,8 @@
       "WebFetch(domain:npmjs.com)",
       "WebFetch(domain:registry.npmjs.org)",
       "Bash(git:*)",
-      "Bash(gh:*)"
+      "Bash(gh:*)",
+      "RemoteTrigger"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Auto-approve Claude Code on the web self check-ins ("send later") without prompting every time by adding `RemoteTrigger` to `permissions.allow` in `.claude/settings.json`.

This propagates the recent change from the `setup-dev-workflow-hooks` skill skeleton.