### PR TITLE
chore: drop the ineffective RemoteTrigger permission rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,7 @@
       "WebFetch(domain:npmjs.com)",
       "WebFetch(domain:registry.npmjs.org)",
       "Bash(git:*)",
-      "Bash(gh:*)",
-      "RemoteTrigger"
+      "Bash(gh:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Part of the same sweep as tk0miya/not_nilable#43, applied to this repository.

`RemoteTrigger` is not a real tool or permission rule name, so the entry in `permissions.allow` never matched anything and the self check-in tools kept prompting on every call. `setup-dev-workflow-hooks` tried replacing it with the actual MCP tool identifiers (`mcp__Claude_Code_Remote__send_later` / `delete_trigger`), verified those had no effect either, and dropped the rule.

Only that one entry is removed here — unlike the other repositories in the sweep, this one has its own `WebFetch(...)` and `Bash(git:*)` / `Bash(gh:*)` rules, which stay as they are.

## Verification

- `permissions.allow` still holds all five project-specific rules; only `RemoteTrigger` is gone.
- `.claude/hooks/self-review.sh` is identical to the skill template (blob SHA `a292e9d`, mode 100755) and unchanged by this PR.
- `actionlint` passes. No workflow files are modified by this PR.

`pre-commit-check.sh` and `claude-code-web-session-start.sh` here are this project's own TypeScript-oriented versions, not the `setup-ruby-hooks` templates, so they are left alone.

No test cases were added: the change removes a configuration entry that had no effect.

## Not applicable here

The rest of the sweep is Ruby-specific (`rbs:regenerate`, `rubocop.yml` ordering, `release.yml` permissions) and does not apply to this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)