### PR TITLE
chore: downgrade @types/node to 24.x (LTS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
         "@types/dedent": "^0.7.2",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.3",
         "dedent": "^1.7.2",
         "playwright": "^1.62.0",
         "tsx": "^4.23.1",
@@ -1263,12 +1263,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
     "@types/dedent": "^0.7.2",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.3",
     "dedent": "^1.7.2",
     "playwright": "^1.62.0",
     "tsx": "^4.23.1",


### PR DESCRIPTION
## Summary

Brings `@types/node` back to the LTS line: `^25.6.0` → `^24.13.3`.

`.github/dependabot.yml` already carries a policy of holding Node.js type definitions at LTS:

```yaml
- dependency-name: "@types/node"
  versions: ["25.x", "26.x", "27.x", "28.x"]
```

That rule only prevents future bumps. The 25.x that had already landed before the rule was added stayed in place, so the declared dependency and the policy disagreed. This closes that gap.

Node 25 is an odd-numbered release and never reaches LTS. Node 24 is the current LTS line, which is what the policy points at.

## Verification

- `npx tsc --noEmit` passes
- `npm test` passes (22 files, 316 tests)

The only lockfile changes are `@types/node` and its `undici-types` dependency.

## Background

The policy and the downgrade were meant to ship together back in April. The policy went in as #136, but the downgrade commit was pushed to the same branch after that PR merged and never became a PR of its own. This picks it up, rebuilt from current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)