### PR TITLE
Have the pre-commit hook call npm run ci

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -14,18 +14,8 @@ cd "$CLAUDE_PROJECT_DIR" || exit 1
 
 echo "Running pre-commit checks..." >&2
 
-if ! npm run lint >&2; then
-    echo "Error: lint failed" >&2
-    exit 2
-fi
-
-if ! npm run typecheck >&2; then
-    echo "Error: typecheck failed" >&2
-    exit 2
-fi
-
-if ! npm test >&2; then
-    echo "Error: tests failed" >&2
+if ! npm run ci >&2; then
+    echo "Error: npm run ci failed" >&2
     exit 2
 fi
 


### PR DESCRIPTION
Syncs `.claude/hooks/pre-commit-check.sh` with the template [tk0miya/skills](https://github.com/tk0miya/skills) 119fd45 added to `init-typescript-project`.

The hook ran `lint`, `typecheck` and `test` one by one. `npm run ci` already chains exactly those three, so calling it keeps the behaviour and leaves the check list defined in one place — `package.json`, which `.github/workflows/ci.yml` also runs.