### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # NOTE: Entries are sorted in ASCII order.
 
+.DS_Store
 /.claude/settings.local.json
 /.claude/worktrees/
 /.env


### PR DESCRIPTION
Syncs `.gitignore` with the `init-typescript-project` template in [tk0miya/skills](https://github.com/tk0miya/skills), which gained the entry in ebb69a6.

Finder drops `.DS_Store` into any directory it opens, so it can turn up anywhere in the tree. The entry goes at the top to keep the file in the ASCII order its header promises.