### PR TITLE
Enable Biome's types domain

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,9 @@
   },
   "linter": {
     "enabled": true,
+    "domains": {
+      "types": "all"
+    },
     "rules": {
       "preset": "recommended"
     }


### PR DESCRIPTION
Adds `linter.domains: { "types": "all" }` to `biome.json`, following [tk0miya/skills](https://github.com/tk0miya/skills) commit `f843982` ("Enable Biome's types domain in the TypeScript template").

Rules that need type inference — `noFloatingPromises` and friends — stay off unless the types domain is turned on. `"all"` rather than `"recommended"` matches the strict stance the template already takes with tsconfig's `"strict": true`.

`npm run lint` still exits 0. The new domain surfaces 4 `noUnnecessaryConditions` warnings in `src/slackutils/checkboxes/main.ts` (redundant `?.` on receivers already proven non-nullish); they are warnings, not errors, and are left for a follow-up so this change stays config-only.