### PR TITLE
Turn off noUnnecessaryConditions

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -20,7 +20,16 @@
       "types": "all"
     },
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "suspicious": {
+        // Off until Biome's type inference stops reporting guards that are
+        // actually required. Deleting a flagged guard produces a null
+        // dereference at runtime, so the rule cannot be acted on as it stands.
+        // https://github.com/biomejs/biome/issues/11360 - useRef(...).current
+        // https://github.com/biomejs/biome/issues/11278 - RegExp.exec()
+        // https://github.com/biomejs/biome/issues/10781 - optional chaining
+        "noUnnecessaryConditions": "off"
+      }
     }
   },
   "javascript": {


### PR DESCRIPTION
Follow-up to #233. The types domain enabled there also switched on `noUnnecessaryConditions`, which left four warnings behind — and every one of them is a guard that is genuinely required:

- `src/michinoeki/main.ts` L54 — `re.exec(html)` returns `RegExpExecArray | null`, but the null check is reported as "always truthy". Removing it throws on any page where the topics div is absent, which is exactly the case `extractUrls` falls back on.
- `src/slackutils/checkboxes/main.ts` L36, L38, L54 — defensive `?.` on values that come out of `as BlockElement[]` / `as CheckboxOption[]` casts over an untrusted Slack payload. The declared type says non-nullable; the runtime data does not.

Upstream issues, linked from the config as comments:

- https://github.com/biomejs/biome/issues/11360 — `useRef(...).current` null-guards, a regression in 2.5.6 (still present in 2.5.9; closed `not_planned` without a fix)
- https://github.com/biomejs/biome/issues/11278 — `RegExp.prototype.exec()` treated as non-nullable
- https://github.com/biomejs/biome/issues/10781 — optional chaining

### biome.json → biome.jsonc

`biome.json` rejects comments — adding them makes Biome fall back to its defaults silently, which drops `files.includes` and starts linting `gas/`, `workflows/` and `.claude/`. `.jsonc` is the supported way to keep the reasoning next to the setting. `biome migrate --write` leaves the file untouched, so the Biome migrate workflow is unaffected.

`npm run lint` goes from 4 warnings to none.